### PR TITLE
Simplify phenopacket loading functions

### DIFF
--- a/docs/user-guide/input-data.rst
+++ b/docs/user-guide/input-data.rst
@@ -5,9 +5,8 @@ Input data
 ==========
 
 The `gpsea` analysis needs to be provided with a standardized form of genotype and phenotype data.
-The analyses require an instance of :class:`gpsea.model.Cohort` that consists
-of :class:`gpsea.model.Patient`\ s - the cohort members. The cohort and the members
-hold the standardized data and provide convenience functions for dataset exploration.
+The analyses require an instance of :class:`~gpsea.model.Cohort` that consists
+of individuals in form of a :class:`~gpsea.model.Patient` class.
 
 .. seealso::
 
@@ -18,14 +17,21 @@ and performing functional annotation of the variants. Here we describe how to pr
 for the exploratory and downstream analysis.
 
 
+***************************************
 Create a cohort from GA4GH phenopackets
----------------------------------------
+***************************************
 
 The easiest way to input data into `gpsea` is to use the
 `GA4GH Phenopacket Schema <https://phenopacket-schema.readthedocs.io/en/latest>`_ phenopackets.
 `gpsea` provides an out-of-the-box solution for loading a cohort from a folder of phenopacket JSON files.
 
 
+Create cohort creator
+=====================
+
+Next, let's prepare a :class:`~gpsea.preprocessing.CohortCreator` that will turn a phenopacket collection
+into a :class:`~gpsea.model.Cohort`. The cohort creator also performs an input validation.
+The validation needs Human Phenotype Ontology data.
 Let's start with loading Human Phenotype Ontology, a requisite for the input Q/C steps. We'll use the amazing
 `hpo-toolkit <https://github.com/TheJacksonLaboratory/hpo-toolkit>`_ library which is installed along with
 the standard `gpsea` installation:
@@ -33,9 +39,6 @@ the standard `gpsea` installation:
 >>> import hpotk
 >>> store = hpotk.configure_ontology_store()
 >>> hpo = store.load_minimal_hpo(release='v2024-07-01')
-
-Next, let's prepare a :class:`~gpsea.preprocessing.CohortCreator` that will turn a collection of phenopacket
-into a :class:`~gpsea.model.Cohort`, required in the downstream steps.
 
 The easiest way to get the `CohortCreator` is to use the
 :func:`~gpsea.preprocessing.configure_caching_cohort_creator` convenience method:
@@ -53,7 +56,12 @@ The easiest way to get the `CohortCreator` is to use the
   and the responses will be cached in the current working directory to reduce the network bandwidth.
   See the :func:`~gpsea.preprocessing.configure_caching_cohort_creator` pydoc for more options.
 
-We can create a cohort starting from a `Phenopacket` collection.
+
+Load phenopackets
+=================
+
+We can create a cohort starting from a collection of `Phenopacket` objects
+provided by Python  `Phenopackets <https://pypi.org/project/phenopackets>`_ library.
 For the purpose of this example, we will load a cohort of patients with pathogenic mutations in *RERE* gene
 included in the release `0.1.18` of `Phenopacket Store <https://github.com/monarch-initiative/phenopacket-store>`_.
 We use `Phenopacket Store Toolkit <https://github.com/monarch-initiative/phenopacket-store-toolkit>`_
@@ -86,8 +94,22 @@ Validated under none policy
 No errors or warnings were found
 
 
-Create a cohort from other data
--------------------------------
+Alternative phenopacket sources
+===============================
 
-TODO - describe how to construct a Patient from raw HPO terms and variant coordinates.
+In case you do not already have a `Phenopacket` collection at your fingertips,
+GPSEA provides a few other convenience functions for loading phenopackets from JSON files.
+
+The :func:`~gpsea.preprocessing.load_phenopacket_files` function can be used to load
+a bunch of phenopacket JSON files:
+
+>>> from gpsea.preprocessing import load_phenopacket_files
+>>> pp_files = ('path/to/phenopacket1.json', 'path/to/phenopacket2.json')
+>>> cohort, qc_results = load_phenopacket_files(pp_files, cohort_creator)  # doctest: +SKIP
+
+or you can load an entire directory of JSON files with :func:`~gpsea.preprocessing.load_phenopacket_folder`:
+
+>>> from gpsea.preprocessing import load_phenopacket_folder
+>>> pp_dir = 'path/to/folder/with/many/phenopacket/json/files'
+>>> cohort, qc_results = load_phenopacket_folder(pp_dir, cohort_creator)  # doctest: +SKIP
 

--- a/src/gpsea/preprocessing/__init__.py
+++ b/src/gpsea/preprocessing/__init__.py
@@ -2,7 +2,7 @@ from ._api import TranscriptCoordinateService, GeneCoordinateService
 from ._api import VariantCoordinateFinder, FunctionalAnnotator, ImpreciseSvFunctionalAnnotator, ProteinMetadataService
 from ._audit import Auditor, DataSanityIssue, Level, Notepad, NotepadTree
 from ._config import configure_caching_patient_creator, configure_patient_creator
-from ._config import load_phenopacket_folder, load_phenopackets
+from ._config import load_phenopacket_folder, load_phenopacket_files, load_phenopackets
 from ._config import configure_caching_cohort_creator, configure_cohort_creator
 from ._config import configure_default_protein_metadata_service, configure_protein_metadata_service
 from ._generic import DefaultImpreciseSvFunctionalAnnotator
@@ -21,7 +21,8 @@ __all__ = [
     'configure_default_protein_metadata_service', 'configure_protein_metadata_service',
     'VariantCoordinateFinder', 'FunctionalAnnotator', 'ImpreciseSvFunctionalAnnotator', 'ProteinMetadataService',
     'PatientCreator', 'CohortCreator',
-    'PhenopacketVariantCoordinateFinder', 'PhenopacketPatientCreator', 'load_phenopacket_folder', 'load_phenopackets',
+    'PhenopacketVariantCoordinateFinder', 'PhenopacketPatientCreator',
+    'load_phenopacket_folder', 'load_phenopacket_files', 'load_phenopackets',
     'TranscriptCoordinateService', 'GeneCoordinateService',
     'PhenotypeCreator',
     'ProteinAnnotationCache', 'ProtCachingMetadataService',


### PR DESCRIPTION
Simplify phenopacket loading functions. Now we can load a collection of `Phenopacket` objects, phenopackets from path to JSON files, and all JSON files in a directory.