### PR TITLE
Simplify MoI predicates

### DIFF
--- a/docs/user-guide/predicates/mode_of_inheritance_predicate.rst
+++ b/docs/user-guide/predicates/mode_of_inheritance_predicate.rst
@@ -4,8 +4,9 @@
 Mode of Inheritance Predicates
 ==============================
 
-There are five basic modes of inheritance for single-gene diseases: autosomal dominant, autosomal recessive, X-linked dominant, X-linked recessive, and mitochondrial (See
-`Understanding Genetics, Appendix B <https://www.ncbi.nlm.nih.gov/books/NBK132145/>`_).
+There are five basic modes of inheritance for single-gene diseases: autosomal dominant, 
+autosomal recessive, X-linked dominant, X-linked recessive, and mitochondrial 
+(See `Understanding Genetics, Appendix B <https://www.ncbi.nlm.nih.gov/books/NBK132145/>`_).
 
 
 The :class:`~gpsea.analysis.predicate.genotype.ModeOfInheritancePredicate`
@@ -15,41 +16,24 @@ The :class:`~gpsea.analysis.predicate.genotype.ModeOfInheritancePredicate` suppo
 the following Mendelian modes of inheritance (MoI):
 
 
-+-----------------------+-----------------------------------+------------------+------------------------+
-|  Mode of inheritance  | Sex                               |   Allele count   |  Genotype category     |
-+=======================+===================================+==================+========================+
-|  Autosomal dominant   | `*`                               |   0              |  `HOM_REF`             |
-+                       +-----------------------------------+------------------+------------------------+
-|                       | `*`                               |   1              |  `HET`                 |
-+                       +-----------------------------------+------------------+------------------------+
-|                       | `*`                               |   :math:`\ge 2`  |  ``None``              |
-+-----------------------+-----------------------------------+------------------+------------------------+
-|  Autosomal recessive  | `*`                               |   0              |  `HOM_REF`             |
-+                       +-----------------------------------+------------------+------------------------+
-|                       | `*`                               |   1              |  `HET`                 |
-+                       +-----------------------------------+------------------+------------------------+
-|                       | `*`                               |   2              |  `BIALLELIC_ALT`       |
-+                       +-----------------------------------+------------------+------------------------+
-|                       | `*`                               |   :math:`\ge 3`  |  ``None``              |
-+-----------------------+-----------------------------------+------------------+------------------------+
-|  X-linked dominant    | `*`                               |   0              |  `HOM_REF`             |
-+                       +-----------------------------------+------------------+------------------------+
-|                       | `*`                               |   1              |  `HET`                 |
-+                       +-----------------------------------+------------------+------------------------+
-|                       | `*`                               |   :math:`\ge 2`  |  ``None``              |
-+-----------------------+-----------------------------------+------------------+------------------------+
-|  X-linked recessive   | `*`                               |   0              |  `HOM_REF`             |
-+                       +-----------------------------------+------------------+------------------------+
-|                       | :class:`~gpsea.model.Sex.FEMALE`  |   1              |  `HET`                 |
-+                       +                                   +------------------+------------------------+
-|                       |                                   |   2              |  `BIALLELIC_ALT`       |
-+                       +                                   +------------------+------------------------+
-|                       |                                   |   :math:`\ge 3`  |  ``None``              |
-+                       +-----------------------------------+------------------+------------------------+
-|                       | :class:`~gpsea.model.Sex.MALE`    |   1              |  `HEMI`                |
-+                       +                                   +------------------+------------------------+
-|                       |                                   |   :math:`\ge 2`  |  ``None``              |
-+-----------------------+-----------------------------------+------------------+------------------------+
++-----------------------+------------------+------------------------+
+|  Mode of inheritance  |   Allele count   |  Genotype category     |
++=======================+==================+========================+
+|  Autosomal dominant   |   0              |  `HOM_REF`             |
++                       +------------------+------------------------+
+|                       |   1              |  `HET`                 |
++                       +------------------+------------------------+
+|                       |   :math:`\ge 2`  |  ``None``              |
++-----------------------+------------------+------------------------+
+|  Autosomal recessive  |   0              |  `HOM_REF`             |
++                       +------------------+------------------------+
+|                       |   1              |  `HET`                 |
++                       +------------------+------------------------+
+|                       |   2              |  `BIALLELIC_ALT`       |
++                       +------------------+------------------------+
+|                       |   :math:`\ge 3`  |  ``None``              |
++-----------------------+------------------+------------------------+
+
 
 .. note::
 
@@ -61,37 +45,49 @@ Then a predicate for the desired MoI can be created by one of
 
 * :func:`~gpsea.analysis.predicate.genotype.ModeOfInheritancePredicate.autosomal_dominant`
 * :func:`~gpsea.analysis.predicate.genotype.ModeOfInheritancePredicate.autosomal_recessive`
-* :func:`~gpsea.analysis.predicate.genotype.ModeOfInheritancePredicate.x_dominant`
-* :func:`~gpsea.analysis.predicate.genotype.ModeOfInheritancePredicate.x_recessive`
 
-All constructors take an instance
-of :class:`~gpsea.analysis.predicate.genotype.VariantPredicate` as an argument.
+By default, the MoI predicates will use *all* variants recorded in the individual.
+However, a :class:`~gpsea.analysis.predicate.genotype.VariantPredicate`
+can be provided to select a variant subset, if necessary.
 
 
-Example
--------
+Assign individuals into genotype groups
+---------------------------------------
 
-Here we show seting up a predicate for grouping individuals based on
-having a variant that leads to a frameshift or to a stop gain to a fictional transcript ``NM_1234.5``
-to test differences between the genotypes of a disease with an autosomal recessive MoI.
+Here we show seting up a predicate for grouping individuals for differences
+between genotypes of a disease with an autosomal recessive MoI.
 
-First, we set up a :class:`~gpsea.analysis.predicate.genotype.VariantPredicate`
-for testing if a variant meets the condition:
+We use :class:`~gpsea.analysis.predicate.genotype.ModeOfInheritancePredicate.autosomal_recessive`
+to create the predicate:
+
+>>> from gpsea.analysis.predicate.genotype import ModeOfInheritancePredicate
+>>> gt_predicate = ModeOfInheritancePredicate.autosomal_recessive()
+>>> gt_predicate.display_question()
+'What is the genotype group: HOM_REF, HET, BIALLELIC_ALT'
+
+The predicate will use *all* recorded variants to determine if the individual belongs into
+homozygous reference (`HOM_REF`), heterozygous (`HET`), or biallelic alternative (`BIALLELIC_ALT`)
+category.
+
+
+Use a subset of variants for choosing the genotype group
+--------------------------------------------------------
+
+To select specific variants, a :class:`~gpsea.analysis.predicate.genotype.VariantPredicate`
+can be registered with the MoI predicate.
+For instance, the following can be done to only consider the variants that lead
+to a missense change on a fictional transcript ``NM_1234.5``
+when assigning the genotype group. We set up the variant predicate:
 
 >>> from gpsea.model import VariantEffect
 >>> from gpsea.analysis.predicate.genotype import VariantPredicates
 >>> tx_id = 'NM_1234.5'
->>> is_frameshift_or_stop_gain = VariantPredicates.variant_effect(VariantEffect.FRAMESHIFT_VARIANT, tx_id) \
-...     | VariantPredicates.variant_effect(VariantEffect.STOP_GAINED, tx_id)
->>> is_frameshift_or_stop_gain.get_question()
-'(FRAMESHIFT_VARIANT on NM_1234.5 OR STOP_GAINED on NM_1234.5)'
+>>> is_missense = VariantPredicates.variant_effect(VariantEffect.MISSENSE_VARIANT, tx_id)
+>>> is_missense.get_question()
+'MISSENSE_VARIANT on NM_1234.5'
 
-Next, we use :class:`~gpsea.analysis.predicate.genotype.ModeOfInheritancePredicate.autosomal_recessive`
-for assigning a patient into a genotype group:
+and we use it to create the MoI predicate:
 
->>> from gpsea.analysis.predicate.genotype import ModeOfInheritancePredicate
->>> gt_predicate = ModeOfInheritancePredicate.autosomal_recessive(is_frameshift_or_stop_gain)
+>>> gt_predicate = ModeOfInheritancePredicate.autosomal_recessive(is_missense)
 >>> gt_predicate.display_question()
 'What is the genotype group: HOM_REF, HET, BIALLELIC_ALT'
-
-The `gt_predicate` can be used in downstream analysis, such as in :class:`~gpsea.analysis.pcats.HpoTermAnalysis`.

--- a/src/gpsea/analysis/predicate/genotype/_counter.py
+++ b/src/gpsea/analysis/predicate/genotype/_counter.py
@@ -8,13 +8,14 @@ class AlleleCounter:
 
     :param predicate: a :class:`VariantPredicate` for selecting the target variants.
     """
-    # TODO: this class should probably be an implementation detail, 
+    # TODO: this class should probably be an implementation detail,
     #   and not a public member of the package.
 
     def __init__(
         self,
         predicate: VariantPredicate,
     ):
+        assert isinstance(predicate, VariantPredicate)
         self._predicate = predicate
 
     def get_question(self) -> str:

--- a/src/gpsea/analysis/predicate/genotype/_gt_predicates.py
+++ b/src/gpsea/analysis/predicate/genotype/_gt_predicates.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 import hpotk
 
+from gpsea.analysis.predicate.genotype._variant import VariantPredicates
 from gpsea.model import Patient, Sex
 
 from .._api import Categorization, PatientCategory
@@ -397,7 +398,7 @@ class ModeOfInheritancePredicate(GenotypePolyPredicate):
 
     @staticmethod
     def autosomal_dominant(
-        variant_predicate: VariantPredicate,
+        variant_predicate: typing.Optional[VariantPredicate] = None,
     ) -> "ModeOfInheritancePredicate":
         """
         Create a predicate that assigns the patient either
@@ -406,6 +407,9 @@ class ModeOfInheritancePredicate(GenotypePolyPredicate):
 
         :param variant_predicate: a predicate for choosing the variants for testing.
         """
+        if variant_predicate is None:
+            variant_predicate = VariantPredicates.true()
+
         return ModeOfInheritancePredicate._from_moi_info(
             variant_predicate=variant_predicate,
             mode_of_inheritance_data=ModeOfInheritanceInfo.autosomal_dominant(),
@@ -413,7 +417,7 @@ class ModeOfInheritancePredicate(GenotypePolyPredicate):
 
     @staticmethod
     def autosomal_recessive(
-        variant_predicate: VariantPredicate,
+        variant_predicate: typing.Optional[VariantPredicate] = None,
     ) -> "ModeOfInheritancePredicate":
         """
         Create a predicate that assigns the patient either into
@@ -423,6 +427,9 @@ class ModeOfInheritancePredicate(GenotypePolyPredicate):
 
         :param variant_predicate: a predicate for choosing the variants for testing.
         """
+        if variant_predicate is None:
+            variant_predicate = VariantPredicates.true()
+
         return ModeOfInheritancePredicate._from_moi_info(
             variant_predicate=variant_predicate,
             mode_of_inheritance_data=ModeOfInheritanceInfo.autosomal_recessive(),

--- a/src/gpsea/analysis/predicate/genotype/_predicates.py
+++ b/src/gpsea/analysis/predicate/genotype/_predicates.py
@@ -10,10 +10,41 @@ from gpsea.preprocessing import ProteinMetadataService
 from ._api import VariantPredicate
 
 
+class AlwaysTrueVariantPredicate(VariantPredicate):
+    """
+    `AlwaysTrueVariantPredicate` returns `True` for any variant.
+    """
+
+    @staticmethod
+    def get_instance() -> "AlwaysTrueVariantPredicate":
+        return ALWAYS_TRUE
+
+    def get_question(self) -> str:
+        return ""
+
+    def test(self, variant: Variant) -> bool:
+        return True
+
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, AlwaysTrueVariantPredicate)
+    
+    def __hash__(self) -> int:
+        return 17
+
+    def __str__(self):
+        return repr(self)
+
+    def __repr__(self):
+        return 'AlwaysTrueVariantPredicate()'
+
+
+ALWAYS_TRUE = AlwaysTrueVariantPredicate()
+
+
 class VariantEffectPredicate(VariantPredicate):
     """
     `VariantEffectPredicate` is a `VariantPredicate` that sets up testing
-    for a specific `VariantEffect` on a given transcript ID. 
+    for a specific `VariantEffect` on a given transcript ID.
     
     Args:
         effect (VariantEffect): the variant effect to search for
@@ -28,16 +59,6 @@ class VariantEffectPredicate(VariantPredicate):
         return f'{self._effect.name} on {self._tx_id}'
 
     def test(self, variant: Variant) -> bool:
-        """Tests if the `Variant` causes the specified `VariantEffect`
-        on the given transcript. 
-
-        Args:
-            variant (Variant): a 
-
-        Returns:
-            bool: _description_
-        """
-        
         tx_anno = variant.get_tx_anno_by_tx_id(self._tx_id)
         if tx_anno is None:
             return False
@@ -98,7 +119,7 @@ class VariantKeyPredicate(VariantPredicate):
 
 class VariantGenePredicate(VariantPredicate):
     """
-    `VariantGenePredicate` tests if the variant 
+    `VariantGenePredicate` tests if the variant
     is annotated to affect a gene denoted by a `symbol`.
 
     Args:
@@ -134,7 +155,7 @@ class VariantGenePredicate(VariantPredicate):
 
 class VariantTranscriptPredicate(VariantPredicate):
     """
-    `VariantTranscriptPredicate` tests if the variant 
+    `VariantTranscriptPredicate` tests if the variant
     is annotated to affect a transcript with `tx_id` accession.
 
     Args:
@@ -170,24 +191,23 @@ class VariantTranscriptPredicate(VariantPredicate):
     
 class VariantExonPredicate(VariantPredicate):
     """
-    `VariantExonPredicate` tests if the variant affects 
+    `VariantExonPredicate` tests if the variant affects
     *n*-th exon of the transcript of interest.
 
     .. warning::
 
-      We use 1-based numbering to number the exons, 
+      We use 1-based numbering to number the exons,
       not the usual 0-based numbering of the computer science.
-      Therefore, the first exon of the transcript 
+      Therefore, the first exon of the transcript
       has ``exon_number==1``, the second exon is ``2``, and so on ...
 
     .. warning::
 
-      We do not check if the `exon_number` spans 
+      We do not check if the `exon_number` spans
       beyond the number of exons of the given `transcript_id`!
-      Therefore, ``exon_number==10,000`` will effectively 
-      return :attr:`GenotypeBooleanPredicate.FALSE`
-      for *all* patients!!! 😱
-      Well, at least the patients of the *Homo sapiens sapiens* taxon...
+      Therefore, ``exon_number==10,000`` will effectively
+      return `False` for *all* variants!!! 😱
+      Well, at least the genomic variants of the *Homo sapiens sapiens* taxon...
 
     :param exon: a positive `int` of the target exon
     :param tx_id: the accession of the transcript of interest, e.g. `NM_123456.7`
@@ -195,10 +215,12 @@ class VariantExonPredicate(VariantPredicate):
     
     def __init__(
         self,
-        exon: int, 
+        exon: int,
         tx_id: str,
     ):
+        assert isinstance(exon, int) and exon > 0, '`exon` must be a positive `int`'
         self._exon = exon
+        assert isinstance(tx_id, str)
         self._tx_id = tx_id
         
     def get_question(self) -> str:
@@ -455,7 +477,8 @@ class ProteinRegionPredicate(VariantPredicate):
         self._tx_id = tx_id
         
     def get_question(self) -> str:
-        return f'variant affects aminoacid(s) between {self._region.start} and {self._region.end} on protein encoded by transcript {self._tx_id}'
+        return f'variant affects aminoacid(s) between {self._region.start} and {self._region.end} ' \
+            f'on protein encoded by transcript {self._tx_id}'
 
     def test(self, variant: Variant) -> bool:
         tx_anno = variant.get_tx_anno_by_tx_id(self._tx_id)
@@ -494,9 +517,9 @@ class ProteinFeatureTypePredicate(VariantPredicate):
     """
     
     def __init__(
-        self, 
-        feature_type: FeatureType, 
-        tx_id: str, 
+        self,
+        feature_type: FeatureType,
+        tx_id: str,
         protein_metadata_service: ProteinMetadataService,
     ):
         self._feature_type = feature_type
@@ -504,7 +527,8 @@ class ProteinFeatureTypePredicate(VariantPredicate):
         self._prot_service = protein_metadata_service
         
     def get_question(self) -> str:
-        return f'variant affects {self._feature_type.name} feature type on the protein encoded by transcript {self._tx_id}'
+        return f'variant affects {self._feature_type.name} feature type on the protein ' \
+            f'encoded by transcript {self._tx_id}'
 
     def test(self, variant: Variant) -> bool:
         tx_anno = variant.get_tx_anno_by_tx_id(self._tx_id)
@@ -519,7 +543,7 @@ class ProteinFeatureTypePredicate(VariantPredicate):
             return False
         
         protein_meta = self._prot_service.annotate(protein_id)
-        for feat in protein_meta.protein_features:    
+        for feat in protein_meta.protein_features:
             if feat.feature_type == self._feature_type and location.overlaps_with(feat.info.region):
                 return True
         return False
@@ -538,7 +562,11 @@ class ProteinFeatureTypePredicate(VariantPredicate):
         return repr(self)
 
     def __repr__(self):
-        return f'ProteinFeatureTypePredicate(feature_type={self._feature_type}, tx_id={self._tx_id}, protein_metadata_service={self._prot_service})'
+        return 'ProteinFeatureTypePredicate(' \
+            f'feature_type={self._feature_type}, ' \
+            f'tx_id={self._tx_id}, ' \
+            f'protein_metadata_service={self._prot_service}' \
+            ')'
 
 
 class ProteinFeaturePredicate(VariantPredicate):
@@ -574,7 +602,7 @@ class ProteinFeaturePredicate(VariantPredicate):
             return False
 
         protein = self._prot_service.annotate(protein_id)
-        for feat in protein.protein_features:    
+        for feat in protein.protein_features:
             if feat.info.name == self._feature_name and location.overlaps_with(feat.info.region):
                 return True
         return False
@@ -593,4 +621,7 @@ class ProteinFeaturePredicate(VariantPredicate):
         return repr(self)
 
     def __repr__(self):
-        return f'ProteinFeaturePredicate(feature_name={self._feature_name}, tx_id={self._tx_id}, protein_metadata_service={self._prot_service})'
+        return f'ProteinFeaturePredicate(' \
+            f'feature_name={self._feature_name}, ' \
+            f'tx_id={self._tx_id}, ' \
+            f'protein_metadata_service={self._prot_service})'

--- a/src/gpsea/analysis/predicate/genotype/_variant.py
+++ b/src/gpsea/analysis/predicate/genotype/_variant.py
@@ -19,6 +19,14 @@ class VariantPredicates:
     """
 
     @staticmethod
+    def true() -> VariantPredicate:
+        """
+        Prepare an absolutely inclusive :class:`VariantPredicate` - a predicate that returns `True`
+        for any variant whatsoever.
+        """
+        return AlwaysTrueVariantPredicate.get_instance()
+
+    @staticmethod
     def all(predicates: typing.Iterable[VariantPredicate]) -> VariantPredicate:
         """
         Prepare a :class:`VariantPredicate` that returns `True` if ALL `predicates` evaluate to `True`.
@@ -139,6 +147,21 @@ class VariantPredicates:
     ) -> VariantPredicate:
         """
         Prepare a :class:`VariantPredicate` that tests if the variant overlaps with an exon of a specific transcript.
+
+        .. warning::
+
+            We use 1-based numbering to number the exons,
+            not the usual 0-based numbering of the computer science.
+            Therefore, the first exon of the transcript
+            has ``exon_number==1``, the second exon is ``2``, and so on ...
+
+        .. warning::
+
+            We do not check if the `exon_number` spans
+            beyond the number of exons of the given `transcript_id`!
+            Therefore, ``exon_number==10,000`` will effectively return `False`
+            for *all* variants!!! 😱
+            Well, at least the genome variants of the *Homo sapiens sapiens* taxon...
 
         Args:
             exon: a non-negative `int` with the index of the target exon

--- a/tests/analysis/predicate/genotype/test_gt_predicates.py
+++ b/tests/analysis/predicate/genotype/test_gt_predicates.py
@@ -113,6 +113,29 @@ class TestModeOfInheritancePredicate:
     @pytest.mark.parametrize(
         "patient_name,name",
         [
+            ("adam", "HET"),  # 0/0 & 0/1
+            ("eve", "HET"),  # 0/1 & 0/0
+            ("cain", "HET"),  # 0/1 & 0/0
+        ],
+    )
+    def test_autosomal_dominant__with_default_predicate(
+        self,
+        patient_name: str,
+        name: str,
+        request: pytest.FixtureRequest,
+    ):
+        patient = request.getfixturevalue(patient_name)
+        predicate = ModeOfInheritancePredicate.autosomal_dominant()
+
+        categorization = predicate.test(patient)
+
+        assert categorization is not None
+
+        assert categorization.category.name == name
+
+    @pytest.mark.parametrize(
+        "patient_name,name",
+        [
             ("walt", "HET"),
             ("skyler", "HET"),
             ("flynn", "BIALLELIC_ALT"),
@@ -128,6 +151,31 @@ class TestModeOfInheritancePredicate:
     ):
         patient = request.getfixturevalue(patient_name)
         predicate = ModeOfInheritancePredicate.autosomal_recessive(variant_predicate)
+
+        categorization = predicate.test(patient)
+
+        assert categorization is not None
+
+        assert categorization.category.name == name
+
+    @pytest.mark.parametrize(
+        "patient_name,name",
+        [
+            # The White family has two variants:
+            ("walt", "BIALLELIC_ALT"),  # 0/1 & 0/1
+            ("skyler", "BIALLELIC_ALT"),  # 0/1 & 0/1
+            ("flynn", "BIALLELIC_ALT"),  # 1/1 & 0/0
+            ("holly", "BIALLELIC_ALT"),  # 0/0 & 1/1
+        ],
+    )
+    def test_autosomal_recessive__with_default_predicate(
+        self,
+        patient_name: str,
+        name: str,
+        request: pytest.FixtureRequest,
+    ):
+        patient = request.getfixturevalue(patient_name)
+        predicate = ModeOfInheritancePredicate.autosomal_recessive()
 
         categorization = predicate.test(patient)
 

--- a/tests/analysis/predicate/genotype/test_predicates.py
+++ b/tests/analysis/predicate/genotype/test_predicates.py
@@ -1,11 +1,18 @@
 import pytest
 
-from gpsea.analysis.predicate.genotype import VariantPredicates, ProteinPredicates, VariantPredicate
+from gpsea.analysis.predicate.genotype import VariantPredicates, ProteinPredicates
 from gpsea.model import *
 from gpsea.model.genome import *
 
 
 class TestVariantPredicates:
+
+    def test_always_true_predicate(
+        self,
+        suox_cohort: Cohort,
+    ):
+        predicate = VariantPredicates.true()
+        assert all(predicate.test(v) for v in suox_cohort.all_variants())
 
     @pytest.mark.parametrize(
         'effect, expected',

--- a/tests/analysis/predicate/genotype/test_predicates.py
+++ b/tests/analysis/predicate/genotype/test_predicates.py
@@ -53,7 +53,7 @@ class TestVariantPredicates:
     @pytest.mark.parametrize(
         'exon, expected',
         [
-            (0, False),
+            (1, False),
             (4, True),
             (5, False),
         ]
@@ -67,6 +67,11 @@ class TestVariantPredicates:
         predicate = VariantPredicates.exon(exon, tx_id='tx:xyz')
 
         assert predicate.test(missense_variant) == expected
+
+    def test_exon_predicate_fails_on_invalid_exon(self):
+        with pytest.raises(AssertionError) as e:
+            VariantPredicates.exon(0, tx_id='tx:xyz')
+        assert e.value.args[0] == '`exon` must be a positive `int`'
 
     @pytest.mark.parametrize(
         'tx_id, expected',


### PR DESCRIPTION
The MoI predicates will consider all variants to determine the genotype group by default. A `VariantPredicate` can be provided to select a subset of variants, if desired.