### PR TITLE
Fix Uniprot API bug

### DIFF
--- a/src/gpsea/analysis/predicate/genotype/_predicates.py
+++ b/src/gpsea/analysis/predicate/genotype/_predicates.py
@@ -359,20 +359,20 @@ class StructuralTypePredicate(VariantPredicate):
 
 
 def _decode_operator(op: str) -> typing.Callable[[int, int], bool]:
-        if op == '<':
-            return operator.lt
-        elif op == '<=':
-            return operator.le
-        elif op == '==':
-            return operator.eq
-        elif op == '!=':
-            return operator.ne
-        elif op == '>=':
-            return operator.ge
-        elif op == '>':
-            return operator.gt
-        else:
-            raise ValueError(f'Unsupported operator {op}')
+    if op == '<':
+        return operator.lt
+    elif op == '<=':
+        return operator.le
+    elif op == '==':
+        return operator.eq
+    elif op == '!=':
+        return operator.ne
+    elif op == '>=':
+        return operator.ge
+    elif op == '>':
+        return operator.gt
+    else:
+        raise ValueError(f'Unsupported operator {op}')
 
 
 class ChangeLengthPredicate(VariantPredicate):
@@ -416,7 +416,7 @@ class ChangeLengthPredicate(VariantPredicate):
 
 class RefAlleleLengthPredicate(VariantPredicate):
     """
-    `RefAlleleLengthPredicate` tests if the length of the variant's reference allele 
+    `RefAlleleLengthPredicate` tests if the length of the variant's reference allele
     is greater than, equal, or less than certain value.
     """
 

--- a/tests/preprocessing/data/uniprot_response/ITPR1_HUMAN.json
+++ b/tests/preprocessing/data/uniprot_response/ITPR1_HUMAN.json
@@ -1,0 +1,446 @@
+{
+  "results": [
+    {
+      "entryType": "UniProtKB reviewed (Swiss-Prot)",
+      "primaryAccession": "Q14643",
+      "uniProtkbId": "ITPR1_HUMAN",
+      "proteinDescription": {
+        "recommendedName": {
+          "fullName": {
+            "evidences": [
+              {
+                "evidenceCode": "ECO:0000305"
+              }
+            ],
+            "value": "Inositol 1,4,5-trisphosphate-gated calcium channel ITPR1"
+          }
+        },
+        "alternativeNames": [
+          {
+            "fullName": {
+              "value": "IP3 receptor isoform 1"
+            },
+            "shortNames": [
+              {
+                "value": "IP3R 1"
+              },
+              {
+                "evidences": [
+                  {
+                    "evidenceCode": "ECO:0000303",
+                    "source": "PubMed",
+                    "id": "7945203"
+                  }
+                ],
+                "value": "InsP3R1"
+              }
+            ]
+          },
+          {
+            "fullName": {
+              "evidences": [
+                {
+                  "evidenceCode": "ECO:0000303",
+                  "source": "PubMed",
+                  "id": "8648241"
+                }
+              ],
+              "value": "Inositol 1,4,5 trisphosphate receptor"
+            }
+          },
+          {
+            "fullName": {
+              "evidences": [
+                {
+                  "evidenceCode": "ECO:0000303",
+                  "source": "PubMed",
+                  "id": "7500840"
+                }
+              ],
+              "value": "Inositol 1,4,5-trisphosphate receptor type 1"
+            }
+          },
+          {
+            "fullName": {
+              "evidences": [
+                {
+                  "evidenceCode": "ECO:0000303",
+                  "source": "PubMed",
+                  "id": "7852357"
+                },
+                {
+                  "evidenceCode": "ECO:0000303",
+                  "source": "PubMed",
+                  "id": "7945203"
+                }
+              ],
+              "value": "Type 1 inositol 1,4,5-trisphosphate receptor"
+            },
+            "shortNames": [
+              {
+                "value": "Type 1 InsP3 receptor"
+              }
+            ]
+          }
+        ]
+      },
+      "genes": [
+        {
+          "geneName": {
+            "evidences": [
+              {
+                "evidenceCode": "ECO:0000303",
+                "source": "PubMed",
+                "id": "7852357"
+              },
+              {
+                "evidenceCode": "ECO:0000312",
+                "source": "HGNC",
+                "id": "HGNC:6180"
+              }
+            ],
+            "value": "ITPR1"
+          },
+          "synonyms": [
+            {
+              "evidences": [
+                {
+                  "evidenceCode": "ECO:0000303",
+                  "source": "PubMed",
+                  "id": "7945203"
+                }
+              ],
+              "value": "INSP3R1"
+            }
+          ]
+        }
+      ],
+      "features": [
+        {
+          "type": "Domain",
+          "location": {
+            "start": {
+              "value": 112,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 166,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "MIR 1",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000255",
+              "source": "PROSITE-ProRule",
+              "id": "PRU00131"
+            }
+          ]
+        },
+        {
+          "type": "Domain",
+          "location": {
+            "start": {
+              "value": 173,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 223,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "MIR 2",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000255",
+              "source": "PROSITE-ProRule",
+              "id": "PRU00131"
+            }
+          ]
+        },
+        {
+          "type": "Domain",
+          "location": {
+            "start": {
+              "value": 231,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 287,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "MIR 3",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000255",
+              "source": "PROSITE-ProRule",
+              "id": "PRU00131"
+            }
+          ]
+        },
+        {
+          "type": "Domain",
+          "location": {
+            "start": {
+              "value": 294,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 373,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "MIR 4",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000255",
+              "source": "PROSITE-ProRule",
+              "id": "PRU00131"
+            }
+          ]
+        },
+        {
+          "type": "Domain",
+          "location": {
+            "start": {
+              "value": 379,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 435,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "MIR 5",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000255",
+              "source": "PROSITE-ProRule",
+              "id": "PRU00131"
+            }
+          ]
+        },
+        {
+          "type": "Region",
+          "location": {
+            "start": {
+              "value": 1015,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 1036,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "Disordered",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000256",
+              "source": "SAM",
+              "id": "MobiDB-lite"
+            }
+          ]
+        },
+        {
+          "type": "Region",
+          "location": {
+            "start": {
+              "value": 1146,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 1178,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "Disordered",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000256",
+              "source": "SAM",
+              "id": "MobiDB-lite"
+            }
+          ]
+        },
+        {
+          "type": "Region",
+          "location": {
+            "start": {
+              "value": 1708,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 1740,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "Disordered",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000256",
+              "source": "SAM",
+              "id": "MobiDB-lite"
+            }
+          ]
+        },
+        {
+          "type": "Region",
+          "location": {
+            "start": {
+              "value": 1760,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 1796,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "Disordered",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000256",
+              "source": "SAM",
+              "id": "MobiDB-lite"
+            }
+          ]
+        },
+        {
+          "type": "Region",
+          "location": {
+            "start": {
+              "value": 1890,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 1915,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "Disordered",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000256",
+              "source": "SAM",
+              "id": "MobiDB-lite"
+            }
+          ]
+        },
+        {
+          "type": "Region",
+          "location": {
+            "start": {
+              "value": 1939,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 1960,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "Disordered",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000256",
+              "source": "SAM",
+              "id": "MobiDB-lite"
+            }
+          ]
+        },
+        {
+          "type": "Region",
+          "location": {
+            "start": {
+              "value": 2472,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 2537,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "Interaction with ERP44",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000250",
+              "source": "UniProtKB",
+              "id": "P11881"
+            }
+          ]
+        },
+        {
+          "type": "Region",
+          "location": {
+            "start": {
+              "value": 2729,
+              "modifier": "EXACT"
+            },
+            "end": {
+              "value": 2758,
+              "modifier": "EXACT"
+            }
+          },
+          "description": "Disordered",
+          "evidences": [
+            {
+              "evidenceCode": "ECO:0000256",
+              "source": "SAM",
+              "id": "MobiDB-lite"
+            }
+          ]
+        }
+      ],
+      "uniProtKBCrossReferences": [
+        {
+          "database": "RefSeq",
+          "id": "NP_001093422.2",
+          "properties": [
+            {
+              "key": "NucleotideSequenceId",
+              "value": "NM_001099952.2"
+            }
+          ],
+          "isoformId": "Q14643-3"
+        },
+        {
+          "database": "RefSeq",
+          "id": "NP_001161744.1",
+          "properties": [
+            {
+              "key": "NucleotideSequenceId",
+              "value": "NM_001168272.1"
+            }
+          ],
+          "isoformId": "Q14643-2"
+        },
+        {
+          "database": "RefSeq",
+          "id": "NP_002213.5",
+          "properties": [
+            {
+              "key": "NucleotideSequenceId",
+              "value": "NM_002222.5"
+            }
+          ],
+          "isoformId": "Q14643-4"
+        },
+        {
+          "database": "RefSeq",
+          "id": "XP_011531985.1",
+          "properties": [
+            {
+              "key": "NucleotideSequenceId",
+              "value": "XM_011533683.2"
+            }
+          ]
+        }
+      ],
+      "sequence": {
+        "length": 2758
+      },
+      "extraAttributes": {
+        "uniParcId": "UPI00015E0851"
+      }
+    }
+  ]
+}

--- a/tests/preprocessing/test_uniprot.py
+++ b/tests/preprocessing/test_uniprot.py
@@ -15,6 +15,11 @@ def fpath_uniprot_response_dir(
     return os.path.join(fpath_preprocessing_data_dir, "uniprot_response")
 
 
+def read_json_payload(path: str) -> typing.Mapping[str, typing.Any]:
+    with open(path) as fh:
+        return json.load(fh)
+
+
 class TestUniprotProteinMetadataService:
 
     @pytest.fixture
@@ -27,8 +32,7 @@ class TestUniprotProteinMetadataService:
         fpath_uniprot_response_dir: str,
     ) -> typing.Mapping[str, typing.Any]:
         fpath_zn462_human = os.path.join(fpath_uniprot_response_dir, "ZN462_HUMAN.json")
-        with open(fpath_zn462_human) as f:
-            return json.load(f)
+        return read_json_payload(fpath_zn462_human)
 
     def test_zn462(
         self,
@@ -44,6 +48,24 @@ class TestUniprotProteinMetadataService:
         assert protein_metadata.label == "Ankyrin repeat domain-containing protein 11"
         assert len(protein_metadata.protein_features) == 16
         assert protein_metadata.protein_length == 2663
+    
+    def test_itpr1(
+        self,
+        fpath_uniprot_response_dir: str,
+    ):
+        response_json_path = os.path.join(fpath_uniprot_response_dir, 'ITPR1_HUMAN.json')
+        response_json = read_json_payload(response_json_path)
+
+        protein_id = "NP_001365381.1"
+        protein_metadata = UniprotProteinMetadataService.parse_uniprot_json(
+            payload=response_json,
+            protein_id=protein_id,
+        )
+
+        assert protein_metadata.protein_id == protein_id
+        assert protein_metadata.label == "Inositol 1,4,5-trisphosphate-gated calcium channel ITPR1"
+        assert len(protein_metadata.protein_features) == 13
+        assert protein_metadata.protein_length == 2758
 
     @pytest.mark.skip("Run manually to regenerate SUOX `NP_001027558.1` metadata")
     def test_fetch_suox_protein_metadata(


### PR DESCRIPTION
Our Uniprot service was not able to get metadata for some protein IDs, such as `NP_001365381.1` of *ITPR1* gene. 

In some cases, the REST response include only one result. If this happens, we will extract the metadata from the response even if there is not an exact match between the query protein ID and the cross-references included in the response.