### PR TITLE
Remove `HMF04` from HPO MTC filter

### DIFF
--- a/docs/report/tbx5_frameshift_vs_missense.csv
+++ b/docs/report/tbx5_frameshift_vs_missense.csv
@@ -1,18 +1,56 @@
 Allele group,Missense,Missense,Frameshift,Frameshift,,
 ,Count,Percent,Count,Percent,Corrected p values,p values
-Ventricular septal defect [HP:0001629],31/60,52%,19/19,100%,0.0008990549794102921,5.6190936213143254e-05
-Abnormal atrioventricular conduction [HP:0005150],0/22,0%,3/3,100%,0.003478260869565217,0.00043478260869565214
-Atrioventricular block [HP:0001678],0/22,0%,2/2,100%,0.01932367149758454,0.0036231884057971015
-Absent thumb [HP:0009777],12/71,17%,14/31,45%,0.022514040627000236,0.005628510156750059
-Patent ductus arteriosus [HP:0001643],3/37,8%,2/2,100%,0.04318488529014845,0.01349527665317139
-Triphalangeal thumb [HP:0001199],13/72,18%,13/32,41%,0.06827099717235872,0.02560162393963452
-Cardiac conduction abnormality [HP:0031546],14/36,39%,3/3,100%,0.17007174901911745,0.07440639019586388
-Secundum atrial septal defect [HP:0001684],14/35,40%,4/22,18%,0.2849045166157176,0.1424522583078588
-Muscular ventricular septal defect [HP:0011623],6/59,10%,6/25,24%,0.29999225997208373,0.1687456462342971
-Pulmonary arterial hypertension [HP:0002092],4/6,67%,0/2,0%,0.6857142857142857,0.42857142857142855
-Hypoplasia of the ulna [HP:0003022],1/12,8%,2/10,20%,0.831168831168831,0.5714285714285713
+Ventricular septal defect [HP:0001629],31/60,52%,19/19,100%,0.003034310555509736,5.6190936213143254e-05
+Abnormal atrioventricular conduction [HP:0005150],0/22,0%,3/3,100%,0.011739130434782608,0.00043478260869565214
+Atrioventricular block [HP:0001678],0/22,0%,2/2,100%,0.06521739130434782,0.0036231884057971015
+Absent thumb [HP:0009777],12/71,17%,14/31,45%,0.0759848871161258,0.005628510156750059
+Patent ductus arteriosus [HP:0001643],3/37,8%,2/2,100%,0.14574898785425103,0.01349527665317139
+Triphalangeal thumb [HP:0001199],13/72,18%,13/32,41%,0.2304146154567107,0.02560162393963452
+Cardiac conduction abnormality [HP:0031546],14/36,39%,3/3,100%,0.5739921529395214,0.07440639019586388
+Secundum atrial septal defect [HP:0001684],14/35,40%,4/22,18%,0.9615527435780469,0.1424522583078588
+Muscular ventricular septal defect [HP:0011623],6/59,10%,6/25,24%,1.0,0.1687456462342971
+Pulmonary arterial hypertension [HP:0002092],4/6,67%,0/2,0%,1.0,0.42857142857142855
+Hypoplasia of the ulna [HP:0003022],1/12,8%,2/10,20%,1.0,0.5714285714285713
 Hypoplasia of the radius [HP:0002984],30/62,48%,6/14,43%,1.0,0.7735491022101784
-Short thumb [HP:0009778],11/41,27%,8/30,27%,1.0,1.0
 Atrial septal defect [HP:0001631],42/44,95%,20/20,100%,1.0,1.0
+Abnormal atrial septum morphology [HP:0011994],43/43,100%,20/20,100%,1.0,1.0
+Abnormal cardiac septum morphology [HP:0001671],62/62,100%,28/28,100%,1.0,1.0
+Abnormal cardiac atrium morphology [HP:0005120],43/43,100%,20/20,100%,1.0,1.0
+Forearm undergrowth [HP:0009821],30/30,100%,7/7,100%,1.0,1.0
+Abnormal appendicular skeleton morphology [HP:0011844],64/64,100%,34/34,100%,1.0,1.0
+Upper limb undergrowth [HP:0009824],33/33,100%,7/7,100%,1.0,1.0
+Aplasia/hypoplasia of the extremities [HP:0009815],55/55,100%,22/22,100%,1.0,1.0
+Aplasia/hypoplasia involving the skeleton [HP:0009115],56/56,100%,23/23,100%,1.0,1.0
+Aplasia/hypoplasia involving bones of the upper limbs [HP:0006496],55/55,100%,22/22,100%,1.0,1.0
+Aplasia/hypoplasia involving bones of the extremities [HP:0045060],55/55,100%,22/22,100%,1.0,1.0
+Aplasia/hypoplasia involving forearm bones [HP:0006503],37/37,100%,12/12,100%,1.0,1.0
+Abnormal forearm bone morphology [HP:0040072],37/37,100%,14/14,100%,1.0,1.0
+Short long bone [HP:0003026],35/35,100%,9/9,100%,1.0,1.0
+Abnormal long bone morphology [HP:0011314],44/44,100%,13/13,100%,1.0,1.0
+Aplasia/Hypoplasia of the radius [HP:0006501],37/37,100%,11/11,100%,1.0,1.0
+Abnormal morphology of the radius [HP:0002818],37/37,100%,13/13,100%,1.0,1.0
+Abnormal hand morphology [HP:0005922],53/53,100%,20/20,100%,1.0,1.0
+Abnormal joint morphology [HP:0001367],31/31,100%,6/6,100%,1.0,1.0
+Abnormal ventricular septum morphology [HP:0010438],31/31,100%,19/19,100%,1.0,1.0
+Aplasia/Hypoplasia of the thumb [HP:0009601],20/20,100%,19/19,100%,1.0,1.0
+Aplasia/Hypoplasia of fingers [HP:0006265],22/22,100%,19/19,100%,1.0,1.0
+Aplasia/hypoplasia involving bones of the hand [HP:0005927],22/22,100%,19/19,100%,1.0,1.0
+Abnormal finger morphology [HP:0001167],36/36,100%,31/31,100%,1.0,1.0
+Abnormal digit morphology [HP:0011297],38/38,100%,33/33,100%,1.0,1.0
+Abnormal thumb morphology [HP:0001172],30/30,100%,31/31,100%,1.0,1.0
+Finger aplasia [HP:0009380],15/15,100%,14/14,100%,1.0,1.0
+Short finger [HP:0009381],11/11,100%,8/8,100%,1.0,1.0
+Short digit [HP:0011927],11/11,100%,10/10,100%,1.0,1.0
+Phocomelia [HP:0009829],8/8,100%,2/2,100%,1.0,1.0
+Short thumb [HP:0009778],11/41,27%,8/30,27%,1.0,1.0
+Abnormal morphology of the great vessels [HP:0030962],6/6,100%,2/2,100%,1.0,1.0
+Abnormal blood vessel morphology [HP:0033353],6/6,100%,2/2,100%,1.0,1.0
+Abnormality of thumb phalanx [HP:0009602],13/13,100%,13/13,100%,1.0,1.0
 Absent radius [HP:0003974],7/32,22%,6/25,24%,1.0,1.0
+Aplasia involving forearm bones [HP:0009822],7/7,100%,6/6,100%,1.0,1.0
+Absent forearm bone [HP:0003953],7/7,100%,6/6,100%,1.0,1.0
 Short humerus [HP:0005792],7/17,41%,4/9,44%,1.0,1.0
+Aplasia/hypoplasia of the humerus [HP:0006507],7/7,100%,4/4,100%,1.0,1.0
+Atrioventricular canal defect [HP:0006695],5/5,100%,3/3,100%,1.0,1.0
+Abnormal thorax morphology [HP:0000765],6/6,100%,5/5,100%,1.0,1.0
+Abnormal axial skeleton morphology [HP:0009121],8/8,100%,5/5,100%,1.0,1.0

--- a/docs/report/tbx5_frameshift_vs_missense.mtc_report.html
+++ b/docs/report/tbx5_frameshift_vs_missense.mtc_report.html
@@ -48,9 +48,9 @@
   <h1>Phenotype testing report</h1>
   <p>Phenotype MTC filter: <em>HPO MTC filter</em></p>
   <p>Multiple testing correction: <em>fdr_bh</em></p>
-  <p>Performed statistical tests for 16 out of the total of 260 HPO terms.</p>
+  <p>Performed statistical tests for 54 out of the total of 260 HPO terms.</p>
     <table>
-      <caption>Using <em>HPO MTC filter</em>, 244 term(s) were omitted from statistical analysis.</caption>
+      <caption>Using <em>HPO MTC filter</em>, 206 term(s) were omitted from statistical analysis.</caption>
         <tbody>
           <tr>
             <th>Code</th>
@@ -73,13 +73,7 @@
           <tr>
             <td>HMF03</td>
             <td>Skipping term because of a child term with the same individual counts</td>
-            <td>1</td>
-          </tr>
-          
-          <tr>
-            <td>HMF04</td>
-            <td>Skipping term because all genotypes have same HPO observed proportions</td>
-            <td>41</td>
+            <td>4</td>
           </tr>
           
           <tr>

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -275,15 +275,15 @@ Now we can perform the analysis and investigate the results.
 ...     pheno_predicates=pheno_predicates,
 ... )
 >>> result.total_tests
-16
+54
 
-We only tested 16 HPO terms. This is despite the individuals being collectively annotated with
+We only tested 54 HPO terms. This is despite the individuals being collectively annotated with
 260 direct and indirect HPO terms
 
 >>> len(result.phenotypes)
 260
 
-We can show the reasoning behind *not* testing 244 (`260 - 16`) HPO terms
+We can show the reasoning behind *not* testing 206 (`260 - 54`) HPO terms
 by exploring the phenotype MTC filtering report.
 
 >>> from gpsea.view import MtcStatsViewer
@@ -312,4 +312,4 @@ was observed in 31/60 (52%) patients with a missense variant
 but it was observed in 19/19 (100%) patients with a frameshift variant.
 Fisher exact test computed a p value of `~0.0000562`
 and the p value corrected by Benjamini-Hochberg procedure
-is `~0.000899`.
+is `~0.003034`.

--- a/docs/user-guide/mtc.rst
+++ b/docs/user-guide/mtc.rst
@@ -235,14 +235,6 @@ and the result of a test, such as the Fisher Exact test, would be exactly the sa
 for *Polar cataract* as for *Posterior polar cataract*.
 
 
-`HMF04` - Skip terms if genotypes have same HPO proportions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If both (or all) of the genotype groups have the same proportion of individuals
-observed to be annotated to an HPO term, e.g., both are 50%, then skip the term,
-because it is not possible that the Fisher exact test will return a significant result.
-
-
 `HMF05` - Skip term if one of the genotype groups has neither observed nor excluded observations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/user-guide/report/tbx5_frameshift.csv
+++ b/docs/user-guide/report/tbx5_frameshift.csv
@@ -1,18 +1,65 @@
 What is the genotype group,HOM_REF,HOM_REF,HET,HET,,
 ,Count,Percent,Count,Percent,Corrected p values,p values
-Ventricular septal defect [HP:0001629],42/71,59%,19/19,100%,0.003870827221893892,0.00024192670136836825
-Abnormal atrioventricular conduction [HP:0005150],1/23,4%,3/3,100%,0.01230769230769231,0.0015384615384615387
-Absent thumb [HP:0009777],18/100,18%,14/31,45%,0.01980624808543961,0.003713671516019927
-Atrioventricular block [HP:0001678],1/23,4%,2/2,100%,0.04,0.01
-Patent ductus arteriosus [HP:0001643],6/40,15%,2/2,100%,0.10406504065040649,0.03252032520325203
-Secundum atrial septal defect [HP:0001684],23/55,42%,4/22,18%,0.15059037690969213,0.06544319142266644
-Triphalangeal thumb [HP:0001199],23/99,23%,13/32,41%,0.15059037690969213,0.06932119159387057
-Cardiac conduction abnormality [HP:0031546],15/37,41%,3/3,100%,0.15059037690969213,0.08259109311740892
-Muscular ventricular septal defect [HP:0011623],8/84,10%,6/25,24%,0.15059037690969213,0.08470708701170182
-Pulmonary arterial hypertension [HP:0002092],8/14,57%,0/2,0%,0.708378140298727,0.4666666666666667
-Short thumb [HP:0009778],25/69,36%,8/30,27%,0.708378140298727,0.48700997145537483
+Ventricular septal defect [HP:0001629],42/71,59%,19/19,100%,0.0152413821862072,0.00024192670136836825
+Abnormal atrioventricular conduction [HP:0005150],1/23,4%,3/3,100%,0.04846153846153847,0.0015384615384615387
+Absent thumb [HP:0009777],18/100,18%,14/31,45%,0.07798710183641847,0.003713671516019927
+Atrioventricular block [HP:0001678],1/23,4%,2/2,100%,0.1575,0.01
+Patent ductus arteriosus [HP:0001643],6/40,15%,2/2,100%,0.4097560975609756,0.03252032520325203
+Secundum atrial septal defect [HP:0001684],23/55,42%,4/22,18%,0.5929496090819127,0.06544319142266644
+Triphalangeal thumb [HP:0001199],23/99,23%,13/32,41%,0.5929496090819127,0.06932119159387057
+Cardiac conduction abnormality [HP:0031546],15/37,41%,3/3,100%,0.5929496090819127,0.08259109311740892
+Muscular ventricular septal defect [HP:0011623],8/84,10%,6/25,24%,0.5929496090819127,0.08470708701170182
+Pulmonary arterial hypertension [HP:0002092],8/14,57%,0/2,0%,1.0,0.4666666666666667
+Short thumb [HP:0009778],25/69,36%,8/30,27%,1.0,0.48700997145537483
 Absent radius [HP:0003974],9/43,21%,6/25,24%,1.0,0.7703831604944444
 Atrial septal defect [HP:0001631],63/65,97%,20/20,100%,1.0,1.0
+Abnormal atrial septum morphology [HP:0011994],64/64,100%,20/20,100%,1.0,1.0
+Abnormal cardiac septum morphology [HP:0001671],89/89,100%,28/28,100%,1.0,1.0
+Abnormal cardiac atrium morphology [HP:0005120],64/64,100%,20/20,100%,1.0,1.0
+Aplasia/Hypoplasia of the thumb [HP:0009601],40/40,100%,19/19,100%,1.0,1.0
+Aplasia/Hypoplasia of fingers [HP:0006265],44/44,100%,19/19,100%,1.0,1.0
+Aplasia/hypoplasia involving bones of the hand [HP:0005927],44/44,100%,19/19,100%,1.0,1.0
+Aplasia/hypoplasia involving bones of the upper limbs [HP:0006496],78/78,100%,22/22,100%,1.0,1.0
+Aplasia/hypoplasia involving bones of the extremities [HP:0045060],78/78,100%,22/22,100%,1.0,1.0
+Aplasia/hypoplasia of the extremities [HP:0009815],78/78,100%,22/22,100%,1.0,1.0
+Aplasia/hypoplasia involving the skeleton [HP:0009115],80/80,100%,23/23,100%,1.0,1.0
+Abnormal appendicular skeleton morphology [HP:0011844],93/93,100%,34/34,100%,1.0,1.0
+Abnormal hand morphology [HP:0005922],75/75,100%,20/20,100%,1.0,1.0
+Abnormal finger morphology [HP:0001167],64/64,100%,31/31,100%,1.0,1.0
+Abnormal digit morphology [HP:0011297],67/67,100%,33/33,100%,1.0,1.0
+Abnormal thumb morphology [HP:0001172],58/58,100%,31/31,100%,1.0,1.0
+Finger aplasia [HP:0009380],23/23,100%,14/14,100%,1.0,1.0
+Aplasia involving forearm bones [HP:0009822],9/9,100%,6/6,100%,1.0,1.0
+Aplasia/hypoplasia involving forearm bones [HP:0006503],43/43,100%,12/12,100%,1.0,1.0
+Abnormal forearm bone morphology [HP:0040072],43/43,100%,14/14,100%,1.0,1.0
+Aplasia/Hypoplasia of the radius [HP:0006501],43/43,100%,11/11,100%,1.0,1.0
+Abnormal morphology of the radius [HP:0002818],43/43,100%,13/13,100%,1.0,1.0
+Absent forearm bone [HP:0003953],9/9,100%,6/6,100%,1.0,1.0
+Abnormal ventricular septum morphology [HP:0010438],42/42,100%,19/19,100%,1.0,1.0
+Abnormal cardiac ventricle morphology [HP:0001713],43/43,100%,19/19,100%,1.0,1.0
+Abnormal axial skeleton morphology [HP:0009121],9/9,100%,5/5,100%,1.0,1.0
+Abnormal thorax morphology [HP:0000765],7/7,100%,5/5,100%,1.0,1.0
+Abnormality of thumb phalanx [HP:0009602],26/26,100%,13/13,100%,1.0,1.0
+Congenital malformation of the great arteries [HP:0011603],7/7,100%,2/2,100%,1.0,1.0
+Abnormal morphology of the great vessels [HP:0030962],10/10,100%,2/2,100%,1.0,1.0
+Abnormal blood vessel morphology [HP:0033353],11/11,100%,2/2,100%,1.0,1.0
+Atrioventricular valve regurgitation [HP:0034376],7/7,100%,2/2,100%,1.0,1.0
+Abnormal atrioventricular valve physiology [HP:0031650],7/7,100%,2/2,100%,1.0,1.0
+Short finger [HP:0009381],27/27,100%,8/8,100%,1.0,1.0
+Short digit [HP:0011927],28/28,100%,10/10,100%,1.0,1.0
+Abnormality of the elbow [HP:0009811],2/2,100%,5/5,100%,1.0,1.0
+Abnormal joint morphology [HP:0001367],33/33,100%,6/6,100%,1.0,1.0
+Abnormality of joint mobility [HP:0011729],3/3,100%,5/5,100%,1.0,1.0
+Deviation of the hand or of fingers of the hand [HP:0009484],5/5,100%,2/2,100%,1.0,1.0
+Atrioventricular canal defect [HP:0006695],6/6,100%,3/3,100%,1.0,1.0
 Hypoplasia of the radius [HP:0002984],34/75,45%,6/14,43%,1.0,1.0
-Hypoplasia of the ulna [HP:0003022],3/17,18%,2/10,20%,1.0,1.0
+Forearm undergrowth [HP:0009821],35/35,100%,7/7,100%,1.0,1.0
+Upper limb undergrowth [HP:0009824],38/38,100%,7/7,100%,1.0,1.0
+Short long bone [HP:0003026],41/41,100%,9/9,100%,1.0,1.0
+Abnormal long bone morphology [HP:0011314],50/50,100%,13/13,100%,1.0,1.0
+Phocomelia [HP:0009829],8/8,100%,2/2,100%,1.0,1.0
+Finger syndactyly [HP:0006101],5/5,100%,2/2,100%,1.0,1.0
 Short humerus [HP:0005792],8/21,38%,4/9,44%,1.0,1.0
+Aplasia/hypoplasia of the humerus [HP:0006507],8/8,100%,4/4,100%,1.0,1.0
+Hypoplasia of the ulna [HP:0003022],3/17,18%,2/10,20%,1.0,1.0
+Abnormal morphology of ulna [HP:0040071],4/4,100%,4/4,100%,1.0,1.0

--- a/docs/user-guide/report/tbx5_frameshift.mtc_report.html
+++ b/docs/user-guide/report/tbx5_frameshift.mtc_report.html
@@ -48,9 +48,9 @@
   <h1>Phenotype testing report</h1>
   <p>Phenotype MTC filter: <em>HPO MTC filter</em></p>
   <p>Multiple testing correction: <em>fdr_bh</em></p>
-  <p>Performed statistical tests for 16 out of the total of 260 HPO terms.</p>
+  <p>Performed statistical tests for 63 out of the total of 260 HPO terms.</p>
     <table>
-      <caption>Using <em>HPO MTC filter</em>, 244 term(s) were omitted from statistical analysis.</caption>
+      <caption>Using <em>HPO MTC filter</em>, 197 term(s) were omitted from statistical analysis.</caption>
         <tbody>
           <tr>
             <th>Code</th>
@@ -73,13 +73,7 @@
           <tr>
             <td>HMF03</td>
             <td>Skipping term because of a child term with the same individual counts</td>
-            <td>1</td>
-          </tr>
-          
-          <tr>
-            <td>HMF04</td>
-            <td>Skipping term because all genotypes have same HPO observed proportions</td>
-            <td>50</td>
+            <td>4</td>
           </tr>
           
           <tr>

--- a/docs/user-guide/stats.rst
+++ b/docs/user-guide/stats.rst
@@ -230,10 +230,10 @@ We can now execute the analysis:
 >>> len(result.phenotypes)
 260
 >>> result.total_tests
-16
+63
 
 
-Thanks to Phenotype MTC filter, we only tested 16 out of 260 terms.
+Thanks to Phenotype MTC filter, we only tested 63 out of 260 terms.
 We can learn more by showing the MTC filter report:
 
 >>> from gpsea.view import MtcStatsViewer
@@ -269,7 +269,7 @@ was observed in 31/60 (52%) patients with a missense variant
 but it was observed in 19/19 (100%) patients with a frameshift variant.
 Fisher exact test computed a p value of `~0.000242`
 and the p value corrected by Benjamini-Hochberg procedure
-is `~0.00387`.
+is `~0.01524`.
 
 The table includes all HPO terms of the cohort, including the terms that were not selected for testing
 and thus have no associated p value.

--- a/tests/analysis/test_mtc_filter.py
+++ b/tests/analysis/test_mtc_filter.py
@@ -128,34 +128,6 @@ class TestHpoMtcFilter:
     @pytest.mark.parametrize(
         "counts, expected",
         [
-            ((10, 100, 50, 500), True),
-            ((0, 0, 100, 100), True),
-            ((10, 100, 50, 500), True),
-            ((10, 100, 10, 105), False),
-            ((95, 60, 144 - 95, 71 - 60), False),
-            ((40, 15, 18, 15), False),
-        ]
-    )
-    def test_genotypes_have_same_hpo_proportions(
-        self,
-        counts: typing.Tuple[int],
-        expected: bool,
-        gt_predicate: GenotypePolyPredicate,
-        ph_predicate: PhenotypePolyPredicate[hpotk.TermId],
-    ):
-        counts_df = TestHpoMtcFilter.prepare_counts_df(counts, gt_predicate, ph_predicate)
-
-        actual = HpoMtcFilter.genotypes_have_same_hpo_proportions(
-            counts=counts_df,
-            gt_predicate=gt_predicate,
-            ph_predicate=ph_predicate,
-        )
-
-        assert actual == expected
-
-    @pytest.mark.parametrize(
-        "counts, expected",
-        [
             ((1, 2, 99, 198), .01),
             ((1, 3, 99, 197), .015),
             ((0, 0, 100, 200), 0.),


### PR DESCRIPTION
The `HMF04` rule peeks at counts, being informed about the genotype predicate.
Therefore, it is removed.

Regarding the filtering based on presence of an HPO term in a certain proportion of individuals (to be implemented for #269), the filter is actually already implemented as `HMF01`.

Fixes #268, #269