### PR TITLE
adding abiulity to filter on annotation  frequency. This requires API…

### DIFF
--- a/src/gpsea/analysis/mtc_filter/_impl.py
+++ b/src/gpsea/analysis/mtc_filter/_impl.py
@@ -22,7 +22,7 @@ class PhenotypeMtcIssue:
     """
     A `str` with a unique code of the issue.
     """
-    
+
     reason: str
     """
     A human-friendly explanation of the issue.
@@ -37,11 +37,15 @@ class PhenotypeMtcResult:
     of be filtered out (:meth:`is_filtered_out`) in which case :attr:`mtc_issue` with more context
     regarding the culprit must be available.
     """
+    # The following is used as a singleton for the "OK" result
+    __ok_instance = None
 
     @staticmethod
     def ok() -> "PhenotypeMtcResult":
-        # A singleton would be nice here...
-        return PhenotypeMtcResult(status=True, issue=None)
+        # singleton
+        if PhenotypeMtcResult.__ok_instance is None:
+            PhenotypeMtcResult.__ok_instance = PhenotypeMtcResult(status=True, issue=None)
+        return PhenotypeMtcResult.__ok_instance
 
     @staticmethod
     def fail(code: str, reason: str) -> "PhenotypeMtcResult":
@@ -49,22 +53,22 @@ class PhenotypeMtcResult:
         return PhenotypeMtcResult(status=False, issue=issue)
 
     def __init__(
-        self,
-        status: bool,
-        issue: typing.Optional[PhenotypeMtcIssue],
+            self,
+            status: bool,
+            issue: typing.Optional[PhenotypeMtcIssue],
     ):
         assert isinstance(status, bool)
         if status:
             assert issue is None, '`issue` must NOT be provided if the HPO term passed the MTC filter'
         else:
             assert issue is not None, '`issue` must be provided if the HPO term failed the MTC filter'
-        
+
         self._status = status
         self._issue = issue
 
     def is_passed(self) -> bool:
         return self._status
-    
+
     def is_filtered_out(self) -> bool:
         return not self._status
 
@@ -78,7 +82,7 @@ class PhenotypeMtcResult:
             return None
         else:
             return self.mtc_issue.reason
-    
+
     def __eq__(self, value: object) -> bool:
         return isinstance(value, PhenotypeMtcResult) \
             and self._status == value._status \
@@ -86,10 +90,10 @@ class PhenotypeMtcResult:
 
     def __hash__(self) -> int:
         return hash((self._status, self._issue))
-    
+
     def __str__(self) -> str:
         return f'PhenotypeMtcResult(status={self._status}, issue={self._issue})'
-    
+
     def __repr__(self) -> str:
         return str(self)
 
@@ -115,10 +119,10 @@ class PhenotypeMtcFilter(typing.Generic[P], metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def filter(
-        self,
-        gt_predicate: GenotypePolyPredicate,
-        ph_predicates: typing.Sequence[PhenotypePolyPredicate[P]],
-        counts: typing.Sequence[pd.DataFrame],
+            self,
+            gt_predicate: GenotypePolyPredicate,
+            ph_predicates: typing.Sequence[PhenotypePolyPredicate[P]],
+            counts: typing.Sequence[pd.DataFrame],
     ) -> typing.Sequence[PhenotypeMtcResult]:
         """
         Test if the phenotype with given counts should be included in the downstream analysis.
@@ -154,10 +158,10 @@ class UseAllTermsMtcFilter(PhenotypeMtcFilter[typing.Any]):
     """
 
     def filter(
-        self,
-        gt_predicate: GenotypePolyPredicate,
-        ph_predicates: typing.Sequence[PhenotypePolyPredicate[P]],
-        counts: typing.Sequence[pd.DataFrame],
+            self,
+            gt_predicate: GenotypePolyPredicate,
+            ph_predicates: typing.Sequence[PhenotypePolyPredicate[P]],
+            counts: typing.Sequence[pd.DataFrame],
     ) -> typing.Sequence[PhenotypeMtcResult]:
         # Always OK! 😏
         return tuple(PhenotypeMtcFilter.OK for _ in ph_predicates)
@@ -177,18 +181,18 @@ class SpecifiedTermsMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
     testing genotype-pehnotype correlations, we can pass the corresponding
     terms to the constructor of this class, thereby preventing other terms from
     being tested and reducing the multiple testing burden.
-    
+
     See :ref:`specify-terms-strategy` section for more info.
     """
-    
+
     NON_SPECIFIED_TERM = PhenotypeMtcResult.fail(code="ST1", reason="Non-specified term")
     """
     The MTC filtering result returned when an HPO term does not belong among the selection of terms to be tested.
     """
 
     def __init__(
-        self,
-        terms_to_test: typing.Iterable[hpotk.TermId],
+            self,
+            terms_to_test: typing.Iterable[hpotk.TermId],
     ):
         """
         Args:
@@ -197,10 +201,10 @@ class SpecifiedTermsMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
         self._terms_to_test_set = set(terms_to_test)
 
     def filter(
-        self,
-        gt_predicate: GenotypePolyPredicate,
-        ph_predicates: typing.Sequence[PhenotypePolyPredicate[P]],
-        counts: typing.Sequence[pd.DataFrame],
+            self,
+            gt_predicate: GenotypePolyPredicate,
+            ph_predicates: typing.Sequence[PhenotypePolyPredicate[P]],
+            counts: typing.Sequence[pd.DataFrame],
     ) -> typing.Sequence[PhenotypeMtcResult]:
         results = []
         for predicate in ph_predicates:
@@ -209,7 +213,7 @@ class SpecifiedTermsMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
             else:
                 results.append(SpecifiedTermsMtcFilter.NON_SPECIFIED_TERM)
         return tuple(results)
-    
+
     def possible_results(self) -> typing.Collection[PhenotypeMtcResult]:
         return (
             PhenotypeMtcFilter.OK,
@@ -242,11 +246,13 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
     SKIPPING_NON_PHENOTYPE_TERM = PhenotypeMtcResult.fail("HMF07", "Skipping non phenotype term")
     SKIPPING_GENERAL_TERM = PhenotypeMtcResult.fail("HMF08", "Skipping general term")
 
+
     @staticmethod
     def default_filter(
-        hpo: hpotk.MinimalOntology,
-        term_frequency_threshold: float,
-        phenotypic_abnormality: hpotk.TermId = hpotk.constants.hpo.base.PHENOTYPIC_ABNORMALITY,
+            hpo: hpotk.MinimalOntology,
+            term_frequency_threshold: float = 0.2,
+            annotation_frequency_threshold: float = 0.25,
+            phenotypic_abnormality: hpotk.TermId = hpotk.constants.hpo.base.PHENOTYPIC_ABNORMALITY,
     ):
         """
         Args:
@@ -255,6 +261,11 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
               for an HPO term to have in at least one of the genotype groups
               (e.g., 22% in missense and 3% in nonsense genotypes would be OK,
               but not 13% missense and 10% nonsense genotypes if the threshold is 0.2)
+            annotation_frequency_threshold: a `float` in range :math:`(0, 1) with the minimum frequency of
+                annotation in the cohort. For instance, if the cohort consists of 100 individuals, and
+                we have explicit observed observations for 20 and excluded for 10 individuals, then the
+                annotation frequency is 0.3. By default, we set a threshold of 25%. The purpose of this
+                threshold is to omit terms for which we simply do not have much data overall.
             phenotypic_abnormality: a :class:`~hpotk.TermId` corresponding to the root of HPO phenotype hierarchy.
               Having to specify this option should be very rarely, if ever.
         """
@@ -300,14 +311,17 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
         return HpoMtcFilter(
             hpo=hpo,
             term_frequency_threshold=term_frequency_threshold,
+            annotation_frequency_threshold=annotation_frequency_threshold,
             general_hpo_terms=general_hpo_term_set,
         )
 
     def __init__(
-        self,
-        hpo: hpotk.MinimalOntology,
-        term_frequency_threshold: float,
-        general_hpo_terms: typing.Iterable[hpotk.TermId],
+            self,
+            hpo: hpotk.MinimalOntology,
+            term_frequency_threshold: float,
+            annotation_frequency_threshold: float,
+            cohort_size: int,
+            general_hpo_terms: typing.Iterable[hpotk.TermId],
     ):
         """
         Args:
@@ -316,16 +330,25 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
               for an HPO term to have in at least one of the genotype groups
               (e.g., 22% in missense and 3% in nonsense genotypes would be OK,
               but not 13% missense and 10% nonsense genotypes if the threshold is 0.2)
+            annotation_frequency_threshold: a `float` in range :math:`(0, 1) with the minimum frequency of annotation
         """
         self._hpo = hpo
         self._hpo_term_frequency_filter = term_frequency_threshold
+        self._hpo_annotation_frequency_threshold = annotation_frequency_threshold
+        self._cohort_size = cohort_size
 
         self._general_hpo_terms = set(general_hpo_terms)
-        
+
         self._below_frequency_threshold = PhenotypeMtcResult.fail(
             code="HMF01",
             reason="Skipping term with maximum frequency that was"
-            f" less than threshold {self._hpo_term_frequency_filter}",
+                   f" less than threshold {self._hpo_term_frequency_filter}",
+        )
+
+        self._below_annotation_frequency_threshold = PhenotypeMtcResult.fail(
+            code="HMF09",
+            reason="Skipping term with maximum annotation frequency that was"
+                   f" less than threshold {self._hpo_annotation_frequency_threshold}",
         )
 
         # Do not perform a test if the counts in the genotype categories do not even have nominal statistical power
@@ -345,24 +368,24 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
         self._not_powered_for_2_by_2 = PhenotypeMtcResult.fail(
             code="HMF06",
             reason=f"Skipping term with less than {self._min_observations_for_2_by_2} observations"
-            " (not powered for 2x2)",
+                   " (not powered for 2x2)",
         )
         self._min_observations_for_2_by_3 = 6
         self._not_powered_for_2_by_3 = PhenotypeMtcResult.fail(
             code="HMF06",
             reason=f"Skipping term with less than {self._min_observations_for_2_by_3} observations"
-            " (not powered for 2x3)",
+                   " (not powered for 2x3)",
         )
 
     def filter(
-        self,
-        gt_predicate: GenotypePolyPredicate,
-        ph_predicates: typing.Sequence[PhenotypePolyPredicate[P]],
-        counts: typing.Sequence[pd.DataFrame],
+            self,
+            gt_predicate: GenotypePolyPredicate,
+            ph_predicates: typing.Sequence[PhenotypePolyPredicate[P]],
+            counts: typing.Sequence[pd.DataFrame],
     ) -> typing.Sequence[PhenotypeMtcResult]:
         phenotypes = [p.phenotype for p in ph_predicates]
         p_to_idx = {p: i for i, p in enumerate(phenotypes)}
-        
+
         results: typing.MutableSequence[typing.Optional[PhenotypeMtcResult]] = [None for _ in range(len(phenotypes))]
         for term_id in self._get_ordered_terms(phenotypes):
             try:
@@ -376,16 +399,16 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
             if term_id in self._general_hpo_terms:
                 results[idx] = HpoMtcFilter.SKIPPING_GENERAL_TERM
                 continue
-            
+
             if not self._hpo.graph.is_ancestor_of(
-                hpotk.constants.hpo.base.PHENOTYPIC_ABNORMALITY, term_id
+                    hpotk.constants.hpo.base.PHENOTYPIC_ABNORMALITY, term_id
             ):
                 results[idx] = HpoMtcFilter.SKIPPING_NON_PHENOTYPE_TERM
                 continue
 
             ph_predicate = ph_predicates[idx]
             contingency_matrix = counts[idx]
-            
+
             max_freq = HpoMtcFilter.get_maximum_group_observed_HPO_frequency(
                 contingency_matrix,
                 ph_predicate=ph_predicate,
@@ -401,17 +424,20 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
             elif contingency_matrix.shape == (2, 3) and total_count < self._min_observations_for_2_by_3:
                 results[idx] = self._not_powered_for_2_by_3
                 continue
+            if total_count / self._cohort_size < self._hpo_annotation_frequency_threshold:
+                results[idx] = self._below_annotation_frequency_threshold
+                continue
 
             if not HpoMtcFilter.some_cell_has_greater_than_one_count(
-                counts=contingency_matrix,
-                ph_predicate=ph_predicate,
+                    counts=contingency_matrix,
+                    ph_predicate=ph_predicate,
             ):
                 results[idx] = HpoMtcFilter.NO_GENOTYPE_HAS_MORE_THAN_ONE_HPO
                 continue
 
             elif HpoMtcFilter.one_genotype_has_zero_hpo_observations(
-                counts=contingency_matrix,
-                gt_predicate=gt_predicate,
+                    counts=contingency_matrix,
+                    gt_predicate=gt_predicate,
             ):
                 results[idx] = HpoMtcFilter.SKIPPING_SINCE_ONE_GENOTYPE_HAD_ZERO_OBSERVATIONS
                 continue
@@ -430,13 +456,13 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
                         # >1 children in the target set.
                         child_contingency_matrix = None
                         break
-            
+
             if child_contingency_matrix is not None:
                 if (contingency_matrix - child_contingency_matrix).abs().max(axis=None) < 1:
                     # Do not test if the count is exactly the same to the counts in the only child term.
                     results[idx] = HpoMtcFilter.SAME_COUNT_AS_THE_ONLY_CHILD
                     continue
-            
+
             # ##
             # The term should be tested if we get here.
             results[idx] = PhenotypeMtcFilter.OK
@@ -448,7 +474,7 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
                 if result is None:
                     term_name = self._hpo.get_term_name(phenotypes[i])
                     missing.append(term_name)
-            
+
             msg = 'Missing results for {}'.format(', '.join(missing))
             raise ValueError(msg)
 
@@ -471,15 +497,15 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
 
     @staticmethod
     def get_number_of_observed_hpo_observations(
-        counts_frame: pd.DataFrame,
-        ph_predicate: PhenotypePolyPredicate[hpotk.TermId],
+            counts_frame: pd.DataFrame,
+            ph_predicate: PhenotypePolyPredicate[hpotk.TermId],
     ) -> int:
         return counts_frame.loc[ph_predicate.present_phenotype_category].sum()
 
     @staticmethod
     def get_maximum_group_observed_HPO_frequency(
-        counts_frame: pd.DataFrame,
-        ph_predicate: PhenotypePolyPredicate[hpotk.TermId],
+            counts_frame: pd.DataFrame,
+            ph_predicate: PhenotypePolyPredicate[hpotk.TermId],
     ) -> float:
         """
         Returns:
@@ -489,26 +515,26 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
         if (all_hpo_count_per_gt == 0).all():
             # Prevent division by zeros
             return 0.
-        
+
         present_hpo_count_per_gt = counts_frame.loc[ph_predicate.present_phenotype_category]
         return (present_hpo_count_per_gt / all_hpo_count_per_gt).max()
 
     @staticmethod
     def one_genotype_has_zero_hpo_observations(
-        counts: pd.DataFrame,
-        gt_predicate: GenotypePolyPredicate,
+            counts: pd.DataFrame,
+            gt_predicate: GenotypePolyPredicate,
     ):
         return any(counts.loc[:, c].sum() == 0 for c in gt_predicate.get_categories())
 
     @staticmethod
     def some_cell_has_greater_than_one_count(
-        counts: pd.DataFrame,
-        ph_predicate: PhenotypePolyPredicate[hpotk.TermId],
+            counts: pd.DataFrame,
+            ph_predicate: PhenotypePolyPredicate[hpotk.TermId],
     ) -> bool:
         """
         If no genotype has more than one HPO count, we do not want to do a test. For instance, if MISSENSE has one
         observed HPO and N excluded, and NOT MISSENSE has zero or one observed HPO, then we will skip the test
-        
+
         Args:
             counts: pandas DataFrame with counts
             ph_predicate: the phenotype predicate that produced the counts
@@ -519,8 +545,8 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
         return (counts.loc[ph_predicate.present_phenotype_category] > 1).any()
 
     def _get_ordered_terms(
-        self,
-        term_ids: typing.Iterable[hpotk.TermId],
+            self,
+            term_ids: typing.Iterable[hpotk.TermId],
     ) -> typing.Sequence[hpotk.TermId]:
         """
         We want to order the terms that were observed in a cohort from the most specific terms
@@ -541,8 +567,8 @@ class HpoMtcFilter(PhenotypeMtcFilter[hpotk.TermId]):
             # TODO: would just children work here too?
             # if no descendant is in the set of annotated terms, then the term must be a leaf term
             if not any(
-                descendant in all_term_ids
-                for descendant in self._hpo.graph.get_descendants(term_id)
+                    descendant in all_term_ids
+                    for descendant in self._hpo.graph.get_descendants(term_id)
             ):
                 hpo_leaf_term_id_set.add(term_id)
 


### PR DESCRIPTION
… change to HpoMtcFilter method

@ielis 
I would like to add the overall frequency of annotation.
e.g., if we have a cohort of size 100, and only 15 patients have information (observed excluded), this can still pass the frequency filter, but it is unlikely to be a good term to test for reasons of statistical power and medical interest (not an important finding and so it is rarely reported).
I think we need to pass the total number of patients to the filter method or the constructor, but this would require an API change. Can we discuss the best way of doing this? 
This was the last thing we discussed with Mike, then we can finalize.