### PR TITLE
Sanitize `SpecifyTermsMtcFilter` input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Developer's secret diary
+Notes.md
+
 # Cache with transcript/protein pickle files
 .gpsea_cache
 dev/

--- a/docs/user-guide/mtc.rst
+++ b/docs/user-guide/mtc.rst
@@ -165,6 +165,8 @@ we pass an iterable (e.g. a tuple) with these two terms as an argument:
 ...         "HP:0002339",  # Abnormal caudate nucleus morphology
 ...     )
 ... )
+>>> len(specified_terms.terms_to_test)
+2
 
 
 .. _hpo-mtc-filter-strategy:


### PR DESCRIPTION
Validate the `SpecifyTermsMtcFilter` inputs. Test the validation.

Fixes #308