### PR TITLE
Generalize analysis results

### DIFF
--- a/docs/user-guide/analyses/measurements.rst
+++ b/docs/user-guide/analyses/measurements.rst
@@ -126,7 +126,7 @@ Show data frame with scores
 
 >>> scores = result.genotype_phenotype_scores.sort_index()
 >>> scores.head()  # doctest: +NORMALIZE_WHITESPACE
-                                     genotype phenotype
+                                     genotype phenotype_score
 patient_id                                                   
 individual 10[PMID_30968594_individual_10]        1     614.0
 individual 11[PMID_30968594_individual_11]        1     630.0

--- a/docs/user-guide/analyses/measurements.rst
+++ b/docs/user-guide/analyses/measurements.rst
@@ -124,15 +124,15 @@ We execute the analysis by running
 
 Show data frame with scores
 
->>> scores = result.genotype_phenotype_scores.sort_index()
+>>> scores = result.data.sort_index()
 >>> scores.head()  # doctest: +NORMALIZE_WHITESPACE
-                                     genotype phenotype_score
-patient_id                                                   
-individual 10[PMID_30968594_individual_10]        1     614.0
-individual 11[PMID_30968594_individual_11]        1     630.0
-individual 12[PMID_30968594_individual_12]        1       NaN
-individual 13[PMID_30968594_individual_13]        1     303.0
-individual 14[PMID_30968594_individual_14]        1     664.0
+                                            genotype  phenotype
+patient_id                                                     
+individual 10[PMID_30968594_individual_10]         1      614.0
+individual 11[PMID_30968594_individual_11]         1      630.0
+individual 12[PMID_30968594_individual_12]         1        NaN
+individual 13[PMID_30968594_individual_13]         1      303.0
+individual 14[PMID_30968594_individual_14]         1      664.0
 
 
 Prepare genotype category legend:

--- a/docs/user-guide/analyses/phenotype-scores.rst
+++ b/docs/user-guide/analyses/phenotype-scores.rst
@@ -270,7 +270,6 @@ to visualize the phenotype score distributions:
 >>> import matplotlib.pyplot as plt
 >>> fig, ax = plt.subplots(figsize=(6, 4), dpi=120)
 >>> result.plot_boxplots(
-...     gt_predicate=gt_predicate,
 ...     ax=ax,
 ... )
 >>> _ = ax.grid(axis="y")

--- a/docs/user-guide/analyses/phenotype-scores.rst
+++ b/docs/user-guide/analyses/phenotype-scores.rst
@@ -244,7 +244,7 @@ To explore further, we can access a data frame with genotype categories and phen
 
 >>> scores = result.genotype_phenotype_scores.sort_index()
 >>> scores.head()  # doctest: +NORMALIZE_WHITESPACE
-                                     genotype phenotype
+                                     genotype phenotype_score
 patient_id
 Subject 10[PMID_27087320_Subject_10]        1         0
 Subject 1[PMID_27087320_Subject_1]          0         4
@@ -253,7 +253,7 @@ Subject 2[PMID_27087320_Subject_2]       None         4
 Subject 2[PMID_29330883_Subject_2]          1         1
 
 
-The data frame provides a `genotype` category and a `phenotype` score for each patient.
+The data frame provides a `genotype` category and a `phenotype_score` for each patient.
 The genotype category should be interpreted in the context of the genotype predicate:
 
 >>> gt_id_to_name = {c.category.cat_id: c.category.name for c in gt_predicate.get_categorizations()}

--- a/docs/user-guide/analyses/phenotype-scores.rst
+++ b/docs/user-guide/analyses/phenotype-scores.rst
@@ -242,15 +242,15 @@ with point vs. loss-of-function mutations.
 
 To explore further, we can access a data frame with genotype categories and phenotype counts:
 
->>> scores = result.genotype_phenotype_scores.sort_index()
+>>> scores = result.data.sort_index()
 >>> scores.head()  # doctest: +NORMALIZE_WHITESPACE
-                                     genotype phenotype_score
+                                      genotype  phenotype
 patient_id
-Subject 10[PMID_27087320_Subject_10]        1         0
-Subject 1[PMID_27087320_Subject_1]          0         4
-Subject 1[PMID_29330883_Subject_1]          1         0
-Subject 2[PMID_27087320_Subject_2]       None         4
-Subject 2[PMID_29330883_Subject_2]          1         1
+Subject 10[PMID_27087320_Subject_10]         1          0
+Subject 1[PMID_27087320_Subject_1]           0          4
+Subject 1[PMID_29330883_Subject_1]           1          0
+Subject 2[PMID_27087320_Subject_2]        None          4
+Subject 2[PMID_29330883_Subject_2]           1          1
 
 
 The data frame provides a `genotype` category and a `phenotype_score` for each patient.

--- a/docs/user-guide/analyses/survival.rst
+++ b/docs/user-guide/analyses/survival.rst
@@ -138,7 +138,7 @@ The `result` includes the survival values for all cohort members:
 
 >>> survivals = result.data.sort_index()
 >>> survivals.head()  # doctest: +NORMALIZE_WHITESPACE
-                          genotype    survival
+                          genotype    phenotype
 patient_id                                                                        
 AII.1[PMID_22034507_AII_1]       0    Survival(value=18262.5, is_censored=True)
 AII.2[PMID_22034507_AII_2]       0    None
@@ -148,7 +148,7 @@ AIII.4[PMID_22034507_AIII_4]     0    Survival(value=19723.5, is_censored=False)
 
 Each line corresponeds to an individual and the dataframe is indexed by the individual's identifier/label.
 The `genotype` column contains the genotype group code,
-and `survival` column includes a :class:`~gpsea.analysis.temporal.Survival` value
+and `phenotype` column includes a :class:`~gpsea.analysis.temporal.Survival` value
 or `None` if computing the survival was impossible (see :func:`~gpsea.analysis.temporal.endpoint.hpo_onset` for details).
 The `Survival` reports the number of days until attaining the endpoint,
 here defined as end stage renal disease (`is_censored=False`),

--- a/src/gpsea/analysis/__init__.py
+++ b/src/gpsea/analysis/__init__.py
@@ -1,0 +1,5 @@
+from ._base import AnalysisResult
+
+__all__ = [
+    "AnalysisResult",
+]

--- a/src/gpsea/analysis/__init__.py
+++ b/src/gpsea/analysis/__init__.py
@@ -1,5 +1,5 @@
-from ._base import AnalysisResult
+from ._base import AnalysisResult, MonoPhenotypeAnalysisResult, MultiPhenotypeAnalysisResult
 
 __all__ = [
-    "AnalysisResult",
+    "AnalysisResult", "MonoPhenotypeAnalysisResult", "MultiPhenotypeAnalysisResult",
 ]

--- a/src/gpsea/analysis/_base.py
+++ b/src/gpsea/analysis/_base.py
@@ -1,4 +1,5 @@
 import abc
+import typing
 
 
 from .predicate.genotype import GenotypePolyPredicate
@@ -40,12 +41,17 @@ class AnalysisResult(metaclass=abc.ABCMeta):
         self,
         gt_predicate: GenotypePolyPredicate,
         statistic: Statistic,
+        mtc_correction: typing.Optional[str]
     ):
         assert isinstance(gt_predicate, GenotypePolyPredicate)
         self._gt_predicate = gt_predicate
 
         assert isinstance(statistic, Statistic)
         self._statistic = statistic
+
+        if mtc_correction is not None:
+            assert isinstance(mtc_correction, str)
+        self._mtc_correction = mtc_correction
     
     @property
     def gt_predicate(self) -> GenotypePolyPredicate:
@@ -60,16 +66,26 @@ class AnalysisResult(metaclass=abc.ABCMeta):
         Get the statistic which computed the (nominal) p values for this result.
         """
         return self._statistic
+    
+    @property
+    def mtc_correction(self) -> typing.Optional[str]:
+        """
+        Get name/code of the used multiple testing correction
+        (e.g. `fdr_bh` for Benjamini-Hochberg) or `None` if no correction was applied.
+        """
+        return self._mtc_correction
 
     # test, p values, corrected values (optional), correction
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, AnalysisResult) \
             and self._gt_predicate == value._gt_predicate \
-            and self._statistic == value._statistic
+            and self._statistic == value._statistic \
+            and self._mtc_correction == value._mtc_correction
     
     def __hash__(self) -> int:
         return hash((
             self._gt_predicate,
             self._statistic,
+            self._mtc_correction,
         ))

--- a/src/gpsea/analysis/_base.py
+++ b/src/gpsea/analysis/_base.py
@@ -9,14 +9,27 @@ class Statistic(metaclass=abc.ABCMeta):
     Mixin for classes that are used to compute a nominal p value for a genotype-phenotype association.
     """
     
+    def __init__(
+        self,
+        name: str,
+    ):
+        self._name = name
+
     @property
-    @abc.abstractmethod
     def name(self) -> str:
         """
         Get the name of the statistic (e.g. `Fisher Exact Test`, `Logrank test`).
         """
-        pass
+        return self._name
     
+    def __eq__(self, value: object) -> bool:
+        if isinstance(value, Statistic):
+            return self._name == value._name
+        return NotImplemented
+    
+    def __hash__(self) -> int:
+        return hash((self._name,))
+
 
 class AnalysisResult(metaclass=abc.ABCMeta):
     """
@@ -26,9 +39,13 @@ class AnalysisResult(metaclass=abc.ABCMeta):
     def __init__(
         self,
         gt_predicate: GenotypePolyPredicate,
+        statistic: Statistic,
     ):
         assert isinstance(gt_predicate, GenotypePolyPredicate)
         self._gt_predicate = gt_predicate
+
+        assert isinstance(statistic, Statistic)
+        self._statistic = statistic
     
     @property
     def gt_predicate(self) -> GenotypePolyPredicate:
@@ -36,12 +53,23 @@ class AnalysisResult(metaclass=abc.ABCMeta):
         Get the genotype predicate used in the survival analysis that produced this result.
         """
         return self._gt_predicate
+    
+    @property
+    def statistic(self) -> Statistic:
+        """
+        Get the statistic which computed the (nominal) p values for this result.
+        """
+        return self._statistic
 
     # test, p values, corrected values (optional), correction
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, AnalysisResult) \
-            and self._gt_predicate == value._gt_predicate
+            and self._gt_predicate == value._gt_predicate \
+            and self._statistic == value._statistic
     
     def __hash__(self) -> int:
-        return hash((self._gt_predicate,))
+        return hash((
+            self._gt_predicate,
+            self._statistic,
+        ))

--- a/src/gpsea/analysis/_base.py
+++ b/src/gpsea/analysis/_base.py
@@ -1,0 +1,5 @@
+import abc
+
+
+class AnalysisResult(metaclass=abc.ABCMeta):
+    pass

--- a/src/gpsea/analysis/_base.py
+++ b/src/gpsea/analysis/_base.py
@@ -4,6 +4,20 @@ import abc
 from .predicate.genotype import GenotypePolyPredicate
 
 
+class Statistic(metaclass=abc.ABCMeta):
+    """
+    Mixin for classes that are used to compute a nominal p value for a genotype-phenotype association.
+    """
+    
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """
+        Get the name of the statistic (e.g. `Fisher Exact Test`, `Logrank test`).
+        """
+        pass
+    
+
 class AnalysisResult(metaclass=abc.ABCMeta):
     """
     `AnalysisResult` includes the common parts of results of all analyses.
@@ -22,6 +36,8 @@ class AnalysisResult(metaclass=abc.ABCMeta):
         Get the genotype predicate used in the survival analysis that produced this result.
         """
         return self._gt_predicate
+
+    # test, p values, corrected values (optional), correction
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, AnalysisResult) \

--- a/src/gpsea/analysis/_base.py
+++ b/src/gpsea/analysis/_base.py
@@ -1,5 +1,31 @@
 import abc
 
 
+from .predicate.genotype import GenotypePolyPredicate
+
+
 class AnalysisResult(metaclass=abc.ABCMeta):
-    pass
+    """
+    `AnalysisResult` includes the common parts of results of all analyses.
+    """
+
+    def __init__(
+        self,
+        gt_predicate: GenotypePolyPredicate,
+    ):
+        assert isinstance(gt_predicate, GenotypePolyPredicate)
+        self._gt_predicate = gt_predicate
+    
+    @property
+    def gt_predicate(self) -> GenotypePolyPredicate:
+        """
+        Get the genotype predicate used in the survival analysis that produced this result.
+        """
+        return self._gt_predicate
+
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, AnalysisResult) \
+            and self._gt_predicate == value._gt_predicate
+    
+    def __hash__(self) -> int:
+        return hash((self._gt_predicate,))

--- a/src/gpsea/analysis/_base.py
+++ b/src/gpsea/analysis/_base.py
@@ -1,4 +1,5 @@
 import abc
+import math
 import typing
 
 
@@ -120,13 +121,37 @@ class MonoPhenotypeAnalysisResult(AnalysisResult, metaclass=abc.ABCMeta):
     `MonoPhenotypeAnalysisResult` reports the outcome of an analysis
     that tested a single genotype-phenotype association.
     """
-    # phenotype, pval
+    # phenotype
+
+    def __init__(
+        self,
+        gt_predicate: GenotypePolyPredicate,
+        statistic: Statistic,
+        pval: float,
+    ):
+        super().__init__(gt_predicate, statistic)
+
+        if isinstance(pval, float) and math.isfinite(pval) and 0.0 <= pval <= 1.0:
+            self._pval = float(pval)
+        else:
+            raise ValueError(
+                f"`pval` must be a finite float in range [0, 1] but it was {pval}"
+            )
+
+    @property
+    def pval(self) -> float:
+        """
+        Get the p value of the test.
+        """
+        return self._pval
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, MonoPhenotypeAnalysisResult) \
-            and super(AnalysisResult, self).__eq__(value)
+            and super(AnalysisResult, self).__eq__(value) \
+            and self._pval == value._pval
     
     def __hash__(self) -> int:
         return hash((
             super(AnalysisResult, self).__hash__(),
+            self._pval,
         ))

--- a/src/gpsea/analysis/pcats/_impl.py
+++ b/src/gpsea/analysis/pcats/_impl.py
@@ -12,11 +12,12 @@ import pandas as pd
 from statsmodels.stats import multitest
 
 from gpsea.model import Patient
-from gpsea.analysis.pcats.stats import CountStatistic
+
 from ..predicate.genotype import GenotypePolyPredicate
 from ..predicate.phenotype import P, PhenotypePolyPredicate
 from ..mtc_filter import PhenotypeMtcFilter, PhenotypeMtcResult
 
+from .stats import CountStatistic
 from .._base import AnalysisResult
 
 DEFAULT_MTC_PROCEDURE = 'fdr_bh'
@@ -104,8 +105,12 @@ class MultiPhenotypeAnalysisResult(typing.Generic[P], AnalysisResult, metaclass=
     def __init__(
         self,
         gt_predicate: GenotypePolyPredicate,
+        statistic: CountStatistic,
     ):
-        super().__init__(gt_predicate)
+        super().__init__(
+            gt_predicate=gt_predicate,
+            statistic=statistic,
+        )
 
     @property
     @abc.abstractmethod
@@ -303,6 +308,7 @@ class BaseMultiPhenotypeAnalysisResult(typing.Generic[P], MultiPhenotypeAnalysis
     def __init__(
         self,
         gt_predicate: GenotypePolyPredicate,
+        statistic: CountStatistic,
         pheno_predicates: typing.Iterable[PhenotypePolyPredicate[P]],
         n_usable: typing.Sequence[int],
         all_counts: typing.Sequence[pd.DataFrame],
@@ -311,6 +317,7 @@ class BaseMultiPhenotypeAnalysisResult(typing.Generic[P], MultiPhenotypeAnalysis
     ):
         super().__init__(
             gt_predicate=gt_predicate,
+            statistic=statistic,
         )
         self._pheno_predicates = tuple(pheno_predicates)
         self._n_usable = tuple(n_usable)
@@ -424,6 +431,7 @@ class DiseaseAnalysis(MultiPhenotypeAnalysis[hpotk.TermId]):
 
         return BaseMultiPhenotypeAnalysisResult(
             gt_predicate=gt_predicate,
+            statistic=self._count_statistic,
             pheno_predicates=pheno_predicates,
             n_usable=n_usable,
             all_counts=all_counts,
@@ -442,23 +450,25 @@ class HpoTermAnalysisResult(BaseMultiPhenotypeAnalysisResult[hpotk.TermId]):
 
     def __init__(
         self,
+        gt_predicate: GenotypePolyPredicate,
+        statistic: CountStatistic,
         pheno_predicates: typing.Iterable[PhenotypePolyPredicate[hpotk.TermId]],
         n_usable: typing.Sequence[int],
         all_counts: typing.Sequence[pd.DataFrame],
         pvals: typing.Sequence[float],
         corrected_pvals: typing.Optional[typing.Sequence[float]],
-        gt_predicate: GenotypePolyPredicate,
         mtc_filter_name: str,
         mtc_filter_results: typing.Sequence[PhenotypeMtcResult],
         mtc_name: typing.Optional[str],
     ):
         super().__init__(
+            gt_predicate=gt_predicate,
+            statistic=statistic,
             pheno_predicates=pheno_predicates,
             n_usable=n_usable,
             all_counts=all_counts,
             pvals=pvals,
             corrected_pvals=corrected_pvals,
-            gt_predicate=gt_predicate,
         )
         self._mtc_filter_name = mtc_filter_name
         self._mtc_filter_results = tuple(mtc_filter_results)
@@ -587,6 +597,7 @@ class HpoTermAnalysis(MultiPhenotypeAnalysis[hpotk.TermId]):
 
         return HpoTermAnalysisResult(
             gt_predicate=gt_predicate,
+            statistic=self._count_statistic,
             pheno_predicates=pheno_predicates,
             n_usable=n_usable,
             all_counts=all_counts,

--- a/src/gpsea/analysis/pcats/_impl.py
+++ b/src/gpsea/analysis/pcats/_impl.py
@@ -179,30 +179,6 @@ class BaseMultiPhenotypeAnalysisResult(typing.Generic[P], MultiPhenotypeAnalysis
         return self._all_counts
 
     @property
-    def pvals(self) -> typing.Sequence[float]:
-        """
-        Get a sequence of nominal p values for each tested HPO term.
-        The sequence includes a `NaN` value for each input phenotype that was *not* tested.
-        """
-        return self._pvals
-
-    @property
-    def corrected_pvals(self) -> typing.Optional[typing.Sequence[float]]:
-        """
-        Get a sequence with p values for each tested HPO term after multiple testing correction
-        or `None` if the correction was not applied.
-        The sequence includes a `NaN` value for each input phenotype that was *not* tested.
-        """
-        return self._corrected_pvals
-
-    @property
-    def total_tests(self) -> int:
-        """
-        Get total count of tests that were run for this analysis.
-        """
-        return sum(1 for pval in self.pvals if not math.isnan(pval))
-
-    @property
     def pheno_predicates(
         self,
     ) -> typing.Sequence[PhenotypePolyPredicate[P]]:
@@ -217,16 +193,12 @@ class BaseMultiPhenotypeAnalysisResult(typing.Generic[P], MultiPhenotypeAnalysis
             and super(MultiPhenotypeAnalysisResult).__eq__(other) \
             and self._pheno_predicates == other._pheno_predicates \
             and self._n_usable == other._n_usable \
-            and self._all_counts == other._all_counts \
-            and self._pvals == other._pvals \
-            and self._corrected_pvals == other._corrected_pvals
+            and self._all_counts == other._all_counts
 
     def __hash__(self):
-        # NOTE: if a field is added, the hash method of the subclasses must be updated as well.
         return hash((
             super(MultiPhenotypeAnalysisResult, self).__hash__(),
             self._pheno_predicates, self._n_usable, self._all_counts,
-            self._pvals, self._corrected_pvals,
         ))
 
 
@@ -476,7 +448,6 @@ class HpoTermAnalysisResult(BaseMultiPhenotypeAnalysisResult[hpotk.TermId]):
         return hash((
             super(BaseMultiPhenotypeAnalysisResult, self).__hash__(),
             self._pheno_predicates, self._n_usable, self._all_counts,
-            self._pvals, self._corrected_pvals,
             self._mtc_filter_name, self._mtc_filter_results,
         ))
 

--- a/src/gpsea/analysis/pcats/_impl.py
+++ b/src/gpsea/analysis/pcats/_impl.py
@@ -17,6 +17,7 @@ from ..predicate.genotype import GenotypePolyPredicate
 from ..predicate.phenotype import P, PhenotypePolyPredicate
 from ..mtc_filter import PhenotypeMtcFilter, PhenotypeMtcResult
 
+from .._base import AnalysisResult
 
 DEFAULT_MTC_PROCEDURE = 'fdr_bh'
 """
@@ -92,7 +93,7 @@ def apply_predicates_on_patients(
     return n_usable_patients, counts
 
 
-class MultiPhenotypeAnalysisResult(typing.Generic[P], metaclass=abc.ABCMeta):
+class MultiPhenotypeAnalysisResult(typing.Generic[P], AnalysisResult, metaclass=abc.ABCMeta):
     """
     `MultiPhenotypeAnalysisResult` reports the outcome of :class:`MultiPhenotypeAnalysis`.
 

--- a/src/gpsea/analysis/pcats/stats/_stats.py
+++ b/src/gpsea/analysis/pcats/stats/_stats.py
@@ -10,8 +10,10 @@ import pandas as pd
 
 import scipy
 
+from ..._base import Statistic
 
-class CountStatistic(metaclass=abc.ABCMeta):
+
+class CountStatistic(Statistic, metaclass=abc.ABCMeta):
     """
     `CountStatistic` calculates a p value for a contingency table
     produced by a pair of discrete random variables.
@@ -65,7 +67,7 @@ class CountStatistic(metaclass=abc.ABCMeta):
 
 class FisherExactTest(CountStatistic):
     """
-    `FisherExactTest` performs Fisher Exact Test on a `2x2` or `2x3` contingency table.
+    `FisherExactTest` performs Fisher's Exact Test on a `2x2` or `2x3` contingency table.
 
     The `2x2` version is a thin wrapper around Scipy :func:`~scipy.stats.fisher_exact` function,
     while the `2x3` variant is implemented in Python.
@@ -74,6 +76,10 @@ class FisherExactTest(CountStatistic):
     
     def __init__(self):
         self._shape = (2, (2, 3))
+
+    @property
+    def name(self) -> str:
+        return "Fisher's Exact Test"
 
     @property
     def supports_shape(

--- a/src/gpsea/analysis/pcats/stats/_stats.py
+++ b/src/gpsea/analysis/pcats/stats/_stats.py
@@ -47,6 +47,9 @@ class CountStatistic(Statistic, metaclass=abc.ABCMeta):
     +------------------------+-------------------------+------------------+
     """
 
+    def __init__(self, name: str):
+        super().__init__(name)
+
     @property
     @abc.abstractmethod
     def supports_shape(
@@ -64,6 +67,12 @@ class CountStatistic(Statistic, metaclass=abc.ABCMeta):
     ) -> float:
         pass
 
+    def __eq__(self, value: object) -> bool:
+        return super().__eq__(value)
+    
+    def __hash__(self) -> int:
+        return super().__hash__()
+
 
 class FisherExactTest(CountStatistic):
     """
@@ -75,11 +84,10 @@ class FisherExactTest(CountStatistic):
     """
     
     def __init__(self):
+        super().__init__(
+            name="Fisher's Exact Test",
+        )
         self._shape = (2, (2, 3))
-
-    @property
-    def name(self) -> str:
-        return "Fisher's Exact Test"
 
     @property
     def supports_shape(
@@ -207,3 +215,9 @@ class FisherExactTest(CountStatistic):
                 else:
                     pos_new = (xx + 1, yy)
                 self._dfs(mat_new, pos_new, r_sum, c_sum, p_0, p)
+
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, FisherExactTest)
+    
+    def __hash__(self) -> int:
+        return 17

--- a/src/gpsea/analysis/pscore/_api.py
+++ b/src/gpsea/analysis/pscore/_api.py
@@ -7,6 +7,8 @@ from gpsea.model import Patient
 from ..predicate.genotype import GenotypePolyPredicate
 from .stats import PhenotypeScoreStatistic
 
+from .._base import AnalysisResult
+
 
 class PhenotypeScorer(metaclass=abc.ABCMeta):
     """
@@ -67,7 +69,7 @@ class FunctionPhenotypeScorer(PhenotypeScorer):
         return self._func(patient)
 
 
-class PhenotypeScoreAnalysisResult:
+class PhenotypeScoreAnalysisResult(AnalysisResult):
     """
     `PhenotypeScoreAnalysisResult` is a container for :class:`PhenotypeScoreAnalysis` results.
     """

--- a/src/gpsea/analysis/pscore/_api.py
+++ b/src/gpsea/analysis/pscore/_api.py
@@ -76,9 +76,13 @@ class PhenotypeScoreAnalysisResult(AnalysisResult):
 
     def __init__(
         self,
+        gt_predicate: GenotypePolyPredicate,
         genotype_phenotype_scores: pd.DataFrame,
         pval: float,
     ):
+        super().__init__(
+            gt_predicate=gt_predicate,
+        )
         self._genotype_phenotype_scores = genotype_phenotype_scores
         if isinstance(pval, float) and 0. <= pval <= 1.:
             self._pval = float(pval)
@@ -118,7 +122,6 @@ class PhenotypeScoreAnalysisResult(AnalysisResult):
 
     def plot_boxplots(
         self,
-        gt_predicate: GenotypePolyPredicate,
         ax,
         colors=("darksalmon", "honeydew"),
     ):
@@ -137,16 +140,16 @@ class PhenotypeScoreAnalysisResult(AnalysisResult):
         # Check that the provided genotype predicate defines the same categories
         # as those found in `data.`
         actual = set(data["genotype"].unique())
-        expected = set(c.cat_id for c in gt_predicate.get_categories())
+        expected = set(c.cat_id for c in self._gt_predicate.get_categories())
         assert actual == expected, 'Mismatch in the genotype categories'
         
         x = [
             data.loc[data["genotype"] == c.category.cat_id, "phenotype"].to_list()
-            for c in gt_predicate.get_categorizations()
+            for c in self._gt_predicate.get_categorizations()
         ]
         
         gt_cat_names = [
-            c.category.name for c in gt_predicate.get_categorizations()
+            c.category.name for c in self._gt_predicate.get_categorizations()
         ]
         bplot = ax.boxplot(
             x=x,
@@ -219,6 +222,7 @@ class PhenotypeScoreAnalysis:
         pval = self._statistic.compute_pval(scores=(x, y))
 
         return PhenotypeScoreAnalysisResult(
+            gt_predicate=gt_predicate,
             genotype_phenotype_scores=data,
             pval=pval,
         )

--- a/src/gpsea/analysis/pscore/_api.py
+++ b/src/gpsea/analysis/pscore/_api.py
@@ -84,6 +84,7 @@ class PhenotypeScoreAnalysisResult(AnalysisResult):
         super().__init__(
             gt_predicate=gt_predicate,
             statistic=statistic,
+            mtc_correction=None,  # Does not apply in phenotype score analysis (yet)
         )
         self._genotype_phenotype_scores = genotype_phenotype_scores
         if isinstance(pval, float) and 0. <= pval <= 1.:

--- a/src/gpsea/analysis/pscore/_api.py
+++ b/src/gpsea/analysis/pscore/_api.py
@@ -77,11 +77,13 @@ class PhenotypeScoreAnalysisResult(AnalysisResult):
     def __init__(
         self,
         gt_predicate: GenotypePolyPredicate,
+        statistic: PhenotypeScoreStatistic,
         genotype_phenotype_scores: pd.DataFrame,
         pval: float,
     ):
         super().__init__(
             gt_predicate=gt_predicate,
+            statistic=statistic,
         )
         self._genotype_phenotype_scores = genotype_phenotype_scores
         if isinstance(pval, float) and 0. <= pval <= 1.:
@@ -223,6 +225,7 @@ class PhenotypeScoreAnalysis:
 
         return PhenotypeScoreAnalysisResult(
             gt_predicate=gt_predicate,
+            statistic=self._statistic,
             genotype_phenotype_scores=data,
             pval=pval,
         )

--- a/src/gpsea/analysis/pscore/_api.py
+++ b/src/gpsea/analysis/pscore/_api.py
@@ -7,7 +7,7 @@ from gpsea.model import Patient
 from ..predicate.genotype import GenotypePolyPredicate
 from .stats import PhenotypeScoreStatistic
 
-from .._base import AnalysisResult
+from .._base import MonoPhenotypeAnalysisResult
 
 
 class PhenotypeScorer(metaclass=abc.ABCMeta):
@@ -69,7 +69,7 @@ class FunctionPhenotypeScorer(PhenotypeScorer):
         return self._func(patient)
 
 
-class PhenotypeScoreAnalysisResult(AnalysisResult):
+class PhenotypeScoreAnalysisResult(MonoPhenotypeAnalysisResult):
     """
     `PhenotypeScoreAnalysisResult` is a container for :class:`PhenotypeScoreAnalysis` results.
     """
@@ -84,7 +84,6 @@ class PhenotypeScoreAnalysisResult(AnalysisResult):
         super().__init__(
             gt_predicate=gt_predicate,
             statistic=statistic,
-            mtc_correction=None,  # Does not apply in phenotype score analysis (yet)
         )
         self._genotype_phenotype_scores = genotype_phenotype_scores
         if isinstance(pval, float) and 0. <= pval <= 1.:

--- a/src/gpsea/analysis/pscore/_api.py
+++ b/src/gpsea/analysis/pscore/_api.py
@@ -84,12 +84,9 @@ class PhenotypeScoreAnalysisResult(MonoPhenotypeAnalysisResult):
         super().__init__(
             gt_predicate=gt_predicate,
             statistic=statistic,
+            pval=pval,
         )
         self._genotype_phenotype_scores = genotype_phenotype_scores
-        if isinstance(pval, float) and 0. <= pval <= 1.:
-            self._pval = float(pval)
-        else:
-            raise ValueError(f"`p_val` must be a finite float in range [0, 1] but it was {pval}")
 
     @property
     def genotype_phenotype_scores(self) -> pd.DataFrame:
@@ -114,13 +111,6 @@ class PhenotypeScoreAnalysisResult(MonoPhenotypeAnalysisResult):
         cannot be assigned into any genotype category.
         """
         return self._genotype_phenotype_scores
-
-    @property
-    def pval(self) -> float:
-        """
-        Get the p value of the test.
-        """
-        return self._pval
 
     def plot_boxplots(
         self,

--- a/src/gpsea/analysis/pscore/stats/_stats.py
+++ b/src/gpsea/analysis/pscore/stats/_stats.py
@@ -21,6 +21,12 @@ class PhenotypeScoreStatistic(Statistic, metaclass=abc.ABCMeta):
     ) -> float:
         pass
 
+    def __eq__(self, value: object) -> bool:
+        return super().__eq__(value)
+    
+    def __hash__(self) -> int:
+        return super().__hash__()
+
 
 class MannWhitneyStatistic(PhenotypeScoreStatistic):
     """
@@ -33,9 +39,10 @@ class MannWhitneyStatistic(PhenotypeScoreStatistic):
     See :ref:`phenotype-score-stats` for an example usage.
     """
     
-    @property
-    def name(self) -> str:
-        return "Mann-Whitney U test"
+    def __init__(self):
+        super().__init__(
+            name="Mann-Whitney U test",
+        )
 
     def compute_pval(
         self,
@@ -60,6 +67,12 @@ class MannWhitneyStatistic(PhenotypeScoreStatistic):
     ) -> typing.Sequence[float]:
         return tuple(val for val in a if not math.isnan(val))
 
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, MannWhitneyStatistic)
+    
+    def __hash__(self) -> int:
+        return 23
+
 
 class TTestStatistic(PhenotypeScoreStatistic):
     """
@@ -70,9 +83,11 @@ class TTestStatistic(PhenotypeScoreStatistic):
     The `NaN` phenotype score values are ignored.
     """
 
-    @property
-    def name(self) -> str:
-        return "Student's t-test"
+    def __init__(self):
+        super().__init__(
+            name="Student's t-test",
+        )
+
     # TODO: refer to a user guide example to show a usage example.
 
     def compute_pval(
@@ -89,3 +104,9 @@ class TTestStatistic(PhenotypeScoreStatistic):
         )
 
         return res.pvalue
+
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, TTestStatistic)
+    
+    def __hash__(self) -> int:
+        return 31

--- a/src/gpsea/analysis/pscore/stats/_stats.py
+++ b/src/gpsea/analysis/pscore/stats/_stats.py
@@ -4,8 +4,10 @@ import typing
 
 from scipy.stats import mannwhitneyu, ttest_ind
 
+from ..._base import Statistic
 
-class PhenotypeScoreStatistic(metaclass=abc.ABCMeta):
+
+class PhenotypeScoreStatistic(Statistic, metaclass=abc.ABCMeta):
     """
     `PhenotypeScoreStatistic` calculates a p value
     for 2 or more phenotype score groups
@@ -31,6 +33,10 @@ class MannWhitneyStatistic(PhenotypeScoreStatistic):
     See :ref:`phenotype-score-stats` for an example usage.
     """
     
+    @property
+    def name(self) -> str:
+        return "Mann-Whitney U test"
+
     def compute_pval(
         self,
         scores: typing.Collection[typing.Sequence[float]],
@@ -64,6 +70,9 @@ class TTestStatistic(PhenotypeScoreStatistic):
     The `NaN` phenotype score values are ignored.
     """
 
+    @property
+    def name(self) -> str:
+        return "Student's t-test"
     # TODO: refer to a user guide example to show a usage example.
 
     def compute_pval(

--- a/src/gpsea/analysis/temporal/_api.py
+++ b/src/gpsea/analysis/temporal/_api.py
@@ -12,6 +12,8 @@ from ..predicate.genotype import GenotypePolyPredicate
 from ._base import Survival
 from .stats import SurvivalStatistic
 
+from .._base import AnalysisResult
+
 
 class Endpoint(metaclass=abc.ABCMeta):
     """
@@ -38,7 +40,7 @@ class Endpoint(metaclass=abc.ABCMeta):
         pass
 
 
-class SurvivalAnalysisResult:
+class SurvivalAnalysisResult(AnalysisResult):
     """
     `SurvivalAnalysisResult` includes the results of a :class:`~gpsea.analysis.temporal.SurvivalAnalysis`.
     """

--- a/src/gpsea/analysis/temporal/_api.py
+++ b/src/gpsea/analysis/temporal/_api.py
@@ -12,7 +12,7 @@ from ..predicate.genotype import GenotypePolyPredicate
 from ._base import Survival
 from .stats import SurvivalStatistic
 
-from .._base import AnalysisResult
+from .._base import MonoPhenotypeAnalysisResult
 
 
 class Endpoint(metaclass=abc.ABCMeta):
@@ -40,7 +40,7 @@ class Endpoint(metaclass=abc.ABCMeta):
         pass
 
 
-class SurvivalAnalysisResult(AnalysisResult):
+class SurvivalAnalysisResult(MonoPhenotypeAnalysisResult):
     """
     `SurvivalAnalysisResult` includes the results of a :class:`~gpsea.analysis.temporal.SurvivalAnalysis`.
     """
@@ -55,7 +55,6 @@ class SurvivalAnalysisResult(AnalysisResult):
         super().__init__(
             gt_predicate=gt_predicate,
             statistic=statistic,
-            mtc_correction=None,  # Does not apply in survival analysis (yet)
         )
 
         assert isinstance(data, pd.DataFrame) and all(
@@ -118,14 +117,14 @@ class SurvivalAnalysisResult(AnalysisResult):
     def __eq__(self, value: object) -> bool:
         return (
             isinstance(value, SurvivalAnalysisResult)
-            and super(AnalysisResult, self).__eq__(value)
+            and super(MonoPhenotypeAnalysisResult, self).__eq__(value)
             and self._data.equals(value._data)
             and self._pval == value._pval
         )
 
     def __hash__(self) -> int:
         return hash((
-            super(AnalysisResult, self).__hash__(),
+            super(MonoPhenotypeAnalysisResult, self).__hash__(),
             self._data,
             self._pval,
         ))

--- a/src/gpsea/analysis/temporal/_api.py
+++ b/src/gpsea/analysis/temporal/_api.py
@@ -55,19 +55,13 @@ class SurvivalAnalysisResult(MonoPhenotypeAnalysisResult):
         super().__init__(
             gt_predicate=gt_predicate,
             statistic=statistic,
+            pval=pval,
         )
 
         assert isinstance(data, pd.DataFrame) and all(
             col in data for col in ("genotype", "survival")
         )
         self._data = data
-
-        if isinstance(pval, float) and math.isfinite(pval) and 0.0 <= pval <= 1.0:
-            self._pval = float(pval)
-        else:
-            raise ValueError(
-                f"`p_val` must be a finite float in range [0, 1] but it was {pval}"
-            )
 
     @property
     def data(self) -> pd.DataFrame:
@@ -107,26 +101,17 @@ class SurvivalAnalysisResult(MonoPhenotypeAnalysisResult):
             self._data["genotype"].notna() & self._data["survival"].notna()
         ]
 
-    @property
-    def pval(self) -> float:
-        """
-        Get the p value of the test.
-        """
-        return self._pval
-
     def __eq__(self, value: object) -> bool:
         return (
             isinstance(value, SurvivalAnalysisResult)
             and super(MonoPhenotypeAnalysisResult, self).__eq__(value)
             and self._data.equals(value._data)
-            and self._pval == value._pval
         )
 
     def __hash__(self) -> int:
         return hash((
             super(MonoPhenotypeAnalysisResult, self).__hash__(),
             self._data,
-            self._pval,
         ))
 
     def __str__(self) -> str:

--- a/src/gpsea/analysis/temporal/_api.py
+++ b/src/gpsea/analysis/temporal/_api.py
@@ -51,8 +51,9 @@ class SurvivalAnalysisResult(AnalysisResult):
         data: pd.DataFrame,
         pval: float,
     ):
-        assert isinstance(gt_predicate, GenotypePolyPredicate)
-        self._gt_predicate = gt_predicate
+        super().__init__(
+            gt_predicate=gt_predicate,
+        )
 
         assert isinstance(data, pd.DataFrame) and all(
             col in data for col in ("genotype", "survival")
@@ -65,13 +66,6 @@ class SurvivalAnalysisResult(AnalysisResult):
             raise ValueError(
                 f"`p_val` must be a finite float in range [0, 1] but it was {pval}"
             )
-
-    @property
-    def gt_predicate(self) -> GenotypePolyPredicate:
-        """
-        Get the genotype predicate used in the survival analysis that produced this result.
-        """
-        return self._gt_predicate
 
     @property
     def data(self) -> pd.DataFrame:
@@ -121,13 +115,17 @@ class SurvivalAnalysisResult(AnalysisResult):
     def __eq__(self, value: object) -> bool:
         return (
             isinstance(value, SurvivalAnalysisResult)
-            and self._gt_predicate == value._gt_predicate
+            and super(AnalysisResult, self).__eq__(value)
             and self._data.equals(value._data)
             and self._pval == value._pval
         )
 
     def __hash__(self) -> int:
-        return hash((self._gt_predicate, self._data, self._pval))
+        return hash((
+            super(AnalysisResult, self).__hash__(),
+            self._data,
+            self._pval,
+        ))
 
     def __str__(self) -> str:
         return (

--- a/src/gpsea/analysis/temporal/_api.py
+++ b/src/gpsea/analysis/temporal/_api.py
@@ -48,11 +48,13 @@ class SurvivalAnalysisResult(AnalysisResult):
     def __init__(
         self,
         gt_predicate: GenotypePolyPredicate,
+        statistic: SurvivalStatistic,
         data: pd.DataFrame,
         pval: float,
     ):
         super().__init__(
             gt_predicate=gt_predicate,
+            statistic=statistic,
         )
 
         assert isinstance(data, pd.DataFrame) and all(
@@ -192,6 +194,7 @@ class SurvivalAnalysis:
 
         return SurvivalAnalysisResult(
             gt_predicate=gt_predicate,
+            statistic=self._statistic,
             data=data,
             pval=pval,
         )

--- a/src/gpsea/analysis/temporal/_api.py
+++ b/src/gpsea/analysis/temporal/_api.py
@@ -55,6 +55,7 @@ class SurvivalAnalysisResult(AnalysisResult):
         super().__init__(
             gt_predicate=gt_predicate,
             statistic=statistic,
+            mtc_correction=None,  # Does not apply in survival analysis (yet)
         )
 
         assert isinstance(data, pd.DataFrame) and all(

--- a/src/gpsea/analysis/temporal/stats/_api.py
+++ b/src/gpsea/analysis/temporal/stats/_api.py
@@ -1,10 +1,11 @@
 import abc
 import typing
 
+from ..._base import Statistic
 from .._base import Survival
 
 
-class SurvivalStatistic(metaclass=abc.ABCMeta):
+class SurvivalStatistic(Statistic, metaclass=abc.ABCMeta):
     """
     `SurvivalStatistic` calculates a p value
     for 2 or more survival groups

--- a/src/gpsea/analysis/temporal/stats/_api.py
+++ b/src/gpsea/analysis/temporal/stats/_api.py
@@ -12,6 +12,9 @@ class SurvivalStatistic(Statistic, metaclass=abc.ABCMeta):
     computed by a :class:`~gpsea.analysis.tempo.SurvivalMetric`.
     """
 
+    def __init__(self, name: str):
+        super().__init__(name)
+
     @abc.abstractmethod
     def compute_pval(
         self,
@@ -22,3 +25,9 @@ class SurvivalStatistic(Statistic, metaclass=abc.ABCMeta):
         the same source distribution.
         """
         pass
+
+    def __eq__(self, value: object) -> bool:
+        return super().__eq__(value)
+    
+    def __hash__(self) -> int:
+        return super().__hash__()

--- a/src/gpsea/analysis/temporal/stats/_impl.py
+++ b/src/gpsea/analysis/temporal/stats/_impl.py
@@ -14,6 +14,10 @@ class LogRankTest(SurvivalStatistic):
     A two-sided alternative hypothesis is tested.
     """
 
+    @property
+    def name(self) -> str:
+        return "Logrank test"
+
     def compute_pval(
         self,
         scores: typing.Collection[typing.Iterable[Survival]],
@@ -23,7 +27,7 @@ class LogRankTest(SurvivalStatistic):
 
         :param scores: a pair of survival groups
         """
-        assert len(scores) == 2, "Log rank test only supports 2 groups at this time"
+        assert len(scores) == 2, "Logrank test only supports 2 groups at this time"
         x, y = tuple(scores)
 
         xc = LogRankTest._prepare_censored_data(x)

--- a/src/gpsea/analysis/temporal/stats/_impl.py
+++ b/src/gpsea/analysis/temporal/stats/_impl.py
@@ -14,9 +14,10 @@ class LogRankTest(SurvivalStatistic):
     A two-sided alternative hypothesis is tested.
     """
 
-    @property
-    def name(self) -> str:
-        return "Logrank test"
+    def __init__(self):
+        super().__init__(
+            name="Logrank test",
+        )
 
     def compute_pval(
         self,
@@ -56,3 +57,9 @@ class LogRankTest(SurvivalStatistic):
             uncensored=uncensored,
             right=right_censored,
         )
+
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, LogRankTest)
+    
+    def __hash__(self) -> int:
+        return 37

--- a/src/gpsea/view/_stats.py
+++ b/src/gpsea/view/_stats.py
@@ -66,7 +66,7 @@ class MtcStatsViewer:
 
         # The following dictionary is used by the Jinja2 HTML template
         return {
-            "mtc_name": report.mtc_name,
+            "mtc_name": report.mtc_correction,
             "hpo_mtc_filter_name": report.mtc_filter_name,
             "skipped_hpo_count": n_skipped,
             "tested_hpo_count": n_tested,

--- a/tests/analysis/pscore/test_pscore_api.py
+++ b/tests/analysis/pscore/test_pscore_api.py
@@ -1,0 +1,54 @@
+import pytest
+
+import pandas as pd
+
+from gpsea.analysis.predicate.genotype import GenotypePolyPredicate
+from gpsea.analysis.pscore import PhenotypeScoreAnalysisResult
+from gpsea.analysis.pscore.stats import MannWhitneyStatistic
+
+
+class TestPhenotypeScoreAnalysisResult:
+
+    @pytest.fixture(scope="class")
+    def result(
+        self,
+        suox_gt_predicate: GenotypePolyPredicate,
+    ) -> PhenotypeScoreAnalysisResult:
+        data = pd.DataFrame(
+            data={
+                "patient_id": ["A", "B", "C"],
+                "genotype": [0, 1, None],
+                "phenotype": [
+                    10.,
+                    float('nan'),
+                    -4.,
+                ],
+            }
+        ).set_index("patient_id")
+        return PhenotypeScoreAnalysisResult(
+            gt_predicate=suox_gt_predicate,
+            statistic=MannWhitneyStatistic(),
+            data=data,
+            pval=0.1234,
+        )
+
+    def test_properties(
+        self,
+        result: PhenotypeScoreAnalysisResult,
+    ):
+        assert tuple(result.gt_predicate.get_category_names()) == (
+            "0",
+            "1",
+        )
+        assert result.data.index.to_list() == ["A", "B", "C"]
+        assert result.pval == pytest.approx(0.1234)
+
+    def test_complete_records(
+        self,
+        result: PhenotypeScoreAnalysisResult,
+    ):
+        records = result.complete_records()
+
+        assert records.shape == (1, 2)
+        assert records.loc["A", "genotype"] == 0
+        assert records.loc["A", "phenotype"] == pytest.approx(10.)

--- a/tests/analysis/temporal/test_api.py
+++ b/tests/analysis/temporal/test_api.py
@@ -84,6 +84,7 @@ class TestSurvivalAnalysisResult:
         ).set_index("patient_id")
         return SurvivalAnalysisResult(
             gt_predicate=umod_gt_predicate,
+            statistic=LogRankTest(),
             data=data,
             pval=0.1234,
         )

--- a/tests/analysis/temporal/test_temporal_api.py
+++ b/tests/analysis/temporal/test_temporal_api.py
@@ -31,7 +31,7 @@ def umod_cohort(
 def umod_gt_predicate() -> GenotypePolyPredicate:
     in_exon_3 = VariantPredicates.exon(3, tx_id="NM_003361.4")
     return monoallelic_predicate(
-        a_predicate=in_exon_3, b_predicate=~in_exon_3, 
+        a_predicate=in_exon_3, b_predicate=~in_exon_3,
         a_label="Exon 3", b_label="Other exon",
     )
 
@@ -75,7 +75,7 @@ class TestSurvivalAnalysisResult:
             data={
                 "patient_id": ["A", "B", "C"],
                 "genotype": [0, 1, None],
-                "survival": [
+                "phenotype": [
                     Survival(value=12.3, is_censored=False),
                     None,
                     Survival(value=45.6, is_censored=True),
@@ -108,4 +108,4 @@ class TestSurvivalAnalysisResult:
 
         assert records.shape == (1, 2)
         assert records.loc["A", "genotype"] == 0
-        assert records.loc["A", "survival"] == Survival(value=12.3, is_censored=False)
+        assert records.loc["A", "phenotype"] == Survival(value=12.3, is_censored=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,8 @@ import os
 import typing
 
 import hpotk
-import numpy as np
-import pandas as pd
 import pytest
 
-from gpsea.analysis.mtc_filter import PhenotypeMtcResult
-from gpsea.analysis.pcats import HpoTermAnalysisResult
 from gpsea.analysis.predicate.genotype import (
     GenotypePolyPredicate,
     VariantPredicates,
@@ -199,57 +195,6 @@ def suox_pheno_predicates(
             hpo=hpo,
             query=hpotk.TermId.from_curie("HP:0001276"),  # Hypertonia
         ),
-    )
-
-
-@pytest.fixture
-def hpo_result(
-    suox_pheno_predicates: typing.Sequence[PhenotypePolyPredicate[hpotk.TermId]],
-    suox_gt_predicate: GenotypePolyPredicate,
-) -> HpoTermAnalysisResult:
-    return HpoTermAnalysisResult(
-        pheno_predicates=suox_pheno_predicates,
-        n_usable=(40, 20, 30, 10, 100),
-        all_counts=tuple(
-            make_count_df(count, suox_gt_predicate, ph_pred)
-            for count, ph_pred in zip(
-                [
-                    (10, 5, 15, 10),
-                    (5, 2, 8, 5),
-                    (10, 5, 5, 10),
-                    (2, 3, 2, 3),
-                    (10, 25, 35, 30),
-                ],
-                suox_pheno_predicates,
-            )
-        ),
-        pvals=(0.01, 0.04, 0.3, 0.2, 0.7),
-        corrected_pvals=(0.04, 0.1, 0.7, 0.5, 1.0),
-        gt_predicate=suox_gt_predicate,
-        mtc_filter_name="MTC filter name",
-        mtc_filter_results=(
-            PhenotypeMtcResult.ok(),
-            PhenotypeMtcResult.ok(),
-            PhenotypeMtcResult.ok(),
-            PhenotypeMtcResult.ok(),
-            PhenotypeMtcResult.ok(),
-        ),
-        mtc_name="MTC name",
-    )
-
-
-def make_count_df(
-    counts: typing.Tuple[int, int, int, int],
-    gt_predicate: GenotypePolyPredicate,
-    ph_predicate: PhenotypePolyPredicate[hpotk.TermId],
-) -> pd.DataFrame:
-    rows = tuple(ph_predicate.get_categories())
-    cols = tuple(gt_predicate.get_categories())
-    data = np.array(counts).reshape((len(rows), len(cols)))
-    return pd.DataFrame(
-        data=data,
-        index=pd.Index(rows),
-        columns=pd.Index(cols),
     )
 
 


### PR DESCRIPTION
Generalize the analysis results into `MultiPhenotypeAnalysisResult` where we test the association with multiple phenotypes (HPO or disease diagnoses) and we perform MT filtering and correction,
and `MonoPhenotypeAnalysisResult` where we only test single genotype-phenotype association (e.g. phenotype score, measurement, or survival).