### PR TITLE
Add convenience methods on `Cohort` and result items

### DIFF
--- a/src/gpsea/analysis/pcats/_impl.py
+++ b/src/gpsea/analysis/pcats/_impl.py
@@ -329,6 +329,12 @@ class HpoTermAnalysisResult(MultiPhenotypeAnalysisResult[hpotk.TermId]):
         """
         return self._mtc_filter_results
 
+    def n_filtered_out(self) -> int:
+        """
+        Get the number of phenotype terms that were filtered out by the MTC filter.
+        """
+        return sum(result.is_filtered_out() for result in self.mtc_filter_results)
+
     def __eq__(self, other):
         return isinstance(other, HpoTermAnalysisResult) \
             and super(MultiPhenotypeAnalysisResult, self).__eq__(other) \

--- a/src/gpsea/analysis/predicate/genotype/_variant.py
+++ b/src/gpsea/analysis/predicate/genotype/_variant.py
@@ -57,7 +57,7 @@ class VariantPredicates:
 
         >>> genes = ('SURF1', 'SURF2',)
         >>> predicate = VariantPredicates.all(VariantPredicates.gene(g) for g in genes)
-        >>> predicate.get_question()
+        >>> predicate.description
         '(affects SURF1 AND affects SURF2)'
 
         Args:
@@ -88,7 +88,7 @@ class VariantPredicates:
         >>> tx_id = 'NM_123456.7'
         >>> effects = (VariantEffect.MISSENSE_VARIANT, VariantEffect.STOP_GAINED,)
         >>> predicate = VariantPredicates.any(VariantPredicates.variant_effect(e, tx_id) for e in effects)
-        >>> predicate.get_question()
+        >>> predicate.description
         '(MISSENSE_VARIANT on NM_123456.7 OR STOP_GAINED on NM_123456.7)'
 
         Args:
@@ -117,7 +117,7 @@ class VariantPredicates:
         >>> from gpsea.model import VariantEffect
         >>> from gpsea.analysis.predicate.genotype import VariantPredicates
         >>> predicate = VariantPredicates.variant_effect(VariantEffect.MISSENSE_VARIANT, tx_id='NM_123.4')
-        >>> predicate.get_question()
+        >>> predicate.description
         'MISSENSE_VARIANT on NM_123.4'
 
         Args:
@@ -278,7 +278,7 @@ class VariantPredicates:
 
         >>> from gpsea.analysis.predicate.genotype import VariantPredicates
         >>> predicate = VariantPredicates.structural_type('SO:1000029')
-        >>> predicate.get_question()
+        >>> predicate.description
         'structural type is SO:1000029'
 
         Args:
@@ -301,7 +301,7 @@ class VariantPredicates:
         >>> from gpsea.model import VariantClass
         >>> from gpsea.analysis.predicate.genotype import VariantPredicates
         >>> predicate = VariantPredicates.variant_class(VariantClass.DEL)
-        >>> predicate.get_question()
+        >>> predicate.description
         'variant class is DEL'
 
         Args:
@@ -359,7 +359,7 @@ class VariantPredicates:
 
         >>> from gpsea.analysis.predicate.genotype import VariantPredicates
         >>> predicate = VariantPredicates.change_length('<=', -10)
-        >>> predicate.get_question()
+        >>> predicate.description
         'change length <= -10'
 
         Args:
@@ -391,7 +391,7 @@ class VariantPredicates:
 
         >>> from gpsea.analysis.predicate.genotype import VariantPredicates
         >>> predicate = VariantPredicates.is_structural_deletion(-20)
-        >>> predicate.get_question()
+        >>> predicate.description
         '(structural type is SO:1000029 OR (variant class is DEL AND change length <= -20))'
 
         Args:

--- a/src/gpsea/view/_base.py
+++ b/src/gpsea/view/_base.py
@@ -1,0 +1,34 @@
+import abc
+
+from jinja2 import Environment, PackageLoader
+
+
+def pluralize(count: int, stem: str) -> str:
+    if isinstance(count, int):
+        if count == 1:
+            return f"{count} {stem}"
+        else:
+            if stem.endswith("s"):
+                return f"{count} {stem}es"
+            else:
+                return f"{count} {stem}s"
+    else:
+        raise ValueError(f"{count} must be an `int`!")
+
+
+def was_were(count: int) -> str:
+    if isinstance(count, int):
+        if count == 1:
+            return "1 was"
+        else:
+            return f"{count} were"
+    else:
+        raise ValueError(f"{count} must be an `int`!")
+
+
+class BaseViewer(metaclass=abc.ABCMeta):
+
+    def __init__(self):
+        self._environment = Environment(loader=PackageLoader("gpsea.view", "templates"))
+        self._environment.filters["pluralize"] = pluralize
+        self._environment.filters["was_were"] = was_were

--- a/src/gpsea/view/templates/cohort.html
+++ b/src/gpsea/view/templates/cohort.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Cohort</title>
-    <style>
+  <style>
     table {
       border-collapse: collapse;
       margin: 25px 0;
@@ -16,6 +17,7 @@
     .table .column-1 {
       text-align: left;
     }
+
     th {
       background-color: LightSkyBlue;
       border: 1px solid #dddddd;
@@ -38,7 +40,8 @@
       background-color: #f2f2f2;
     }
 
-    .table td, tr {
+    .table td,
+    tr {
       text-align: right;
     }
 
@@ -50,7 +53,8 @@
       display: block;
       width: 100%;
       padding-right: 1%;
-      margin-bottom: 20px; /* Add margin to separate divs */
+      margin-bottom: 20px;
+      /* Add margin to separate divs */
     }
 
     caption {
@@ -64,133 +68,165 @@
 
 <body>
   <h1>GPSEA cohort analysis</h1>
-  <p>Successfully loaded {{ n_individuals }} individuals. {{ n_male }} were recorded as male, {{ n_female }} as female,
-      and {{ n_unknown_sex }} as unknown sex. {{ n_alive }} were reported to be alive at the time of last
-      encounter, and {{ n_deceased }} were deceased. {{ n_has_disease_onset }} had disease onset information
-      and {{n_has_age_at_last_encounter  }} had information about the age at last encounter. In the cohort,
-      there were a total of {{ total_hpo_count }} HPO terms used for annotation.
-    {% if total_measurement_count > 0 %}
-      Information was provided for {{ total_measurement_count }}
-      measurement assays.
+  <p>
+    Successfully loaded {{ cohort | count | pluralize('individual') }}.
+
+    {# Sex #}
+    {{ cohort.count_males() | was_were }} recorded as male,
+    {{ cohort.count_females() }} as female,
+    and {{ cohort.count_unknown_sex() }} as unknown sex.
+
+    {# Vital status #}
+    {% if cohort | count == cohort.count_unknown_vital_status() %}
+    No information about individuals' vital status was reported.
+    {% else %}
+    {{ cohort.count_alive() | was_were }} reported to be alive at the time of last encounter,
+    {{ cohort.count_deceased() | was_were }} deceased,
+    and vital status was unreported for {{ cohort.count_unknown_vital_status() | pluralize('individual')}}.
+    {% endif %}
+
+    {# HPO terms #}
+    The cohort included {{ cohort.count_distinct_hpo_terms() | pluralize('HPO term') }}.
+
+    {# Disease and age at last encounter #}
+    {{ cohort.count_with_disease_onset() | pluralize('individual')}} had disease onset information
+    and {{ cohort.count_with_age_of_last_encounter() }} had information about the age of last encounter.
+
+
+    {# Measurements #}
+    {% if cohort.all_measurement | count > 0 %}
+    Information was provided for {{ cohort.all_measurement | count | pluralize('measurement assay') }}.
     {% endif %}
   </p>
-  {% if n_excluded > 0 %}
-  <p>Not able to load {{ n_excluded }} individuals.</p>
+
+  {% if cohort.get_excluded_count() > 0 %}
+  <p>Not able to load {{ cohort.get_excluded_count() }} individuals.</p>
   {% else %}
   <p>No errors encountered.</p>
   {% endif %}
 
-    <table>
+  {# The most common HPO terms #}
+  <table>
     <caption style="color: black;">
-        <h3>Top {{top_hpo_count}} HPO Terms</h3>
-        A total of {{ total_hpo_count }} HPO terms were used to annotated the cohort.
+      <h3>Top {{top_hpo_count}} HPO terms</h3>
+      A total of {{ cohort.count_distinct_hpo_terms() }} HPO terms were used to annotated the cohort.
+      {% if n_has_onset_info %} {# Optional onset info #}
+      {{ n_has_onset_info }} had onset information for at least 20% of individuals.
+      {% endif %}
     </caption>
-        <tbody>
-            <tr class="strng">
-                <th class="lft">HPO Term</th>
-                <th>ID</th>
-                <th>Seen in <em>n</em> individuals</th>
-            </tr>
-            {% for hpo_count in hpo_counts %}
-            <tr>
-                <td class="lft">{{ hpo_count.HPO }}</td>
-                <td>{{ hpo_count.ID }}</td>
-                <td>{{ hpo_count.Count }}</td>
-                </tr>
-            {% endfor %}
-                </tbody>
-    </table>
+    <tbody>
+      <tr class="strng">
+        <th class="lft">HPO Term</th>
+        <th>ID</th>
+        <th>Seen in <em>n</em> individuals</th>
+      </tr>
 
+      {% for count in hpo_counts %}
+      <tr>
+        <td class="lft">{{ count['label'] }}</td>
+        <td>{{ count['term_id'] }}</td>
+        <td>{{ count['count'] }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  {# The table is inconsistent. Skip it for now!
   {% if n_has_onset_info > 0 %}
-      <p> {{ n_has_onset_info }} had onset information for at least 20% of individuals.</p>
-       <caption style="color: black;">
-        <h3>Top {{top_var_count}} HPO Terms</h3>
-        A total of {{ total_hpo_count }} HPO terms were used to annotated the cohort.
-    </caption>
-            <tbody>
-                <tr class="strng">
-                    <th>HPO</th>
-                    <th>Count</th>
-                </tr>
-                {% for onset_info in has_onset_information %}
-                <tr>
-                    <td>{{ onset_info.display_label }}</td>
-                    <td>{{ onset_info.count }}</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    <table>
-
+  <h3>Top {{top_var_count}} HPO Terms</h3>
+  <p>
+    A total of {{ cohort.count_distinct_hpo_terms() }} HPO terms were used to annotated the cohort.
+  </p>
+  <table>
+    <tbody>
+      <tr class="strng">
+        <th>HPO</th>
+        <th>Count</th>
+      </tr>
+      {% for onset_info in has_onset_information %}
+      <tr>
+        <td>{{ onset_info.display_label }}</td>
+        <td>{{ onset_info.count }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
   {% endif %}
+  #}
 
-    <table>
+  {# The most common variants #}
+  <table>
     <caption style="color: black;">
-        <h3>Top {{top_var_count}} Variants</h3>
-        Variants are shown according to {{ transcript_id }}. A total of {{ unique_variant_count}} unique variants were identified in the cohort.
+      <h3>Top {{top_var_count}} variants</h3>
+      Variants are shown according to {{ transcript_id }}.
+      A total of {{ cohort.all_variant_infos() | count | pluralize('unique variant') }}
+      were identified in the cohort.
     </caption>
-            <tbody>
-                <tr class="strng">
-                    <th>Seen in <em>n</em> individuals</th>
-                    <th class="lft">Variant key</th>
-                    <th>Variant Name</th>
-                    <th>Protein Variant</th>
-                    <th>Variant Class</th>
-                </tr>
-                {% for var_count in var_counts %}
-                <tr>
-                    <td>{{ var_count.Count }}</td>
-                    <td class="lft">{{ var_count.variant }}</td>
-                    <td>{{ var_count.variant_name }}</td>
-                    <td>{{ var_count.protein_name }}</td>
-                    <td>{{ var_count.variant_effects }}</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    <table>
+    <tbody>
+      <tr class="strng">
+        <th>Seen in <em>n</em> individuals</th>
+        <th class="lft">Variant key</th>
+        <th>Variant Name</th>
+        <th>Protein Effect</th>
+        <th>Variant Class</th>
+      </tr>
+      {% for count in var_counts %}
+      <tr>
+        <td>{{ count['count'] }}</td>
+        <td class="lft">{{ count['key'] }}</td>
+        <td>{{ count['hgvsc'] }}</td>
+        <td>{{ count['hgvsp'] }}</td>
+        <td>{{ count['effects'] }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  
+  {# The most common diseases #}
+  <table>
     <caption style="color: black;">
-        <h3>Diseases</h3>
+      <h3>Diseases</h3>
     </caption>
-        <tbody>
-            <tr class="strng">
-                <th class="lft">Disease Name</th>
-                <th >Disease ID</th>
-                <th>Annotation Count</th>
-              </tr>
-              {% for disease_count in disease_counts %}
-              <tr>
-                <td class="lft">{{ disease_count.disease_name   }}</td>
-                <td>{{ disease_count.disease_id }}</td>
-                <td>{{ disease_count.count }}</td>
-                </tr>
-            {% endfor %}
-           </tbody>
-    </table>
-    {% if has_transcript > 0 %}
-    <table>
+    <tbody>
+      <tr class="strng">
+        <th class="lft">Name</th>
+        <th>ID</th>
+        <th><em>N</em> diagnosed individuals</th>
+      </tr>
+      {% for disease_count in disease_counts %}
+      <tr>
+        <td class="lft">{{ disease_count['label'] }}</td>
+        <td>{{ disease_count['disease_id'] }}</td>
+        <td>{{ disease_count['count'] }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  
+  {# The most common variant effects #}
+  {% if has_transcript %}
+  <table>
     <caption style="color: black;">
-        <h3>Variant categories for {{ transcript_id }}</h3>
+      <h3>Variant categories for {{ transcript_id }}</h3>
     </caption>
-        <tbody>
-            <tr class="strng">
-                <th class="lft">Variant effect</th>
-                <th>Annotation Count</th>
-                <th>Percent</th>
-              </tr>
-              {% for var_effect in var_effects_list %}
-              <tr>
-                <td class="lft">{{ var_effect.effect }}</td>
-                <td>{{ var_effect.count }}</td>
-               <td>{{ var_effect.percent }}</td>
-                </tr>
-            {% endfor %}
-           </tbody>
-    </table>
+    <tbody>
+      <tr class="strng">
+        <th class="lft">Variant effect</th>
+        <th>Annotation count</th>
+        <th>Percent</th>
+      </tr>
+      {% for effect in variant_effects %}
+      <tr>
+        <td class="lft">{{ effect['effect'] }}</td>
+        <td>{{ effect['count'] }}</td>
+        <td>{{ effect['percent'] }}%</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
   {% else %}
   <p>Call this function with transcript to see table with variant effect counts.</p>
   {% endif %}
-
 
 </body>
 </html>

--- a/tests/analysis/test_analysis_result.py
+++ b/tests/analysis/test_analysis_result.py
@@ -1,0 +1,82 @@
+import math
+import typing
+
+import hpotk
+import pandas as pd
+import pytest
+
+from gpsea.analysis import MultiPhenotypeAnalysisResult
+from gpsea.analysis.predicate.genotype import GenotypePolyPredicate
+from gpsea.analysis.predicate.phenotype import HpoPredicate
+from gpsea.analysis.pcats.stats import FisherExactTest
+
+
+@pytest.fixture(scope="class")
+def multi_phenotype_analysis_result(
+    hpo: hpotk.MinimalOntology,
+    suox_gt_predicate: GenotypePolyPredicate,
+) -> MultiPhenotypeAnalysisResult:
+    is_arachnodactyly = HpoPredicate(
+        hpo=hpo,
+        query=hpotk.TermId.from_curie("HP:0001166"),  # Arachnodactyly
+    )
+    is_seizure = HpoPredicate(
+        hpo=hpo,
+        query=hpotk.TermId.from_curie("HP:0001250"),  # Seizure
+    )
+    is_polydactyly = HpoPredicate(
+        hpo=hpo,
+        query=hpotk.TermId.from_curie("HP:0100259"),  # Postaxial polydactyly
+    )
+    is_clinodactyly = HpoPredicate(
+        hpo=hpo,
+        query=hpotk.TermId.from_curie("HP:0030084"),  # Clinodactyly
+    )
+    return MultiPhenotypeAnalysisResult(
+        gt_predicate=suox_gt_predicate,
+        statistic=FisherExactTest(),
+        mtc_correction="fdr_bh",
+        pheno_predicates=(
+            is_arachnodactyly,
+            is_seizure,
+            is_polydactyly,
+            is_clinodactyly,
+        ),
+        n_usable=(40, 20, 115, 10),
+        all_counts=(
+            pd.DataFrame(
+                data=[[10, 5], [10, 15]],
+                index=pd.Index(is_arachnodactyly.get_categories()),
+                columns=pd.Index(suox_gt_predicate.get_categories()),
+            ),
+            pd.DataFrame(
+                data=[[5, 0], [5, 10]],
+                index=pd.Index(is_seizure.get_categories()),
+                columns=pd.Index(suox_gt_predicate.get_categories()),
+            ),
+            pd.DataFrame(
+                data=[[50, 0], [5, 60]],
+                index=pd.Index(is_polydactyly.get_categories()),
+                columns=pd.Index(suox_gt_predicate.get_categories()),
+            ),
+            pd.DataFrame(
+                data=[[0, 0], [10, 0]],
+                index=pd.Index(is_clinodactyly.get_categories()),
+                columns=pd.Index(suox_gt_predicate.get_categories()),
+            ),
+        ),
+        pvals=(math.nan, 0.005, 0.0005, .05),
+        corrected_pvals=(math.nan, 0.01, 0.001, .5),
+    )
+
+
+class TestMultiPhenotypeAnalysisResult:
+
+    def test_significant_phenotype_indices(
+        self,
+        multi_phenotype_analysis_result: MultiPhenotypeAnalysisResult,
+    ):
+        indices = multi_phenotype_analysis_result.significant_phenotype_indices(
+            alpha=0.05, pval_kind="corrected"
+        )
+        assert indices == (2, 1)

--- a/tests/view/test_view.py
+++ b/tests/view/test_view.py
@@ -1,4 +1,4 @@
-import io
+import os
 
 import hpotk
 import pytest
@@ -7,6 +7,7 @@ from gpsea.model import Cohort
 from gpsea.view import CohortViewer
 
 
+@pytest.mark.skip("Just for manual testing and debugging")
 class TestCohortViewer:
 
     @pytest.fixture
@@ -21,17 +22,13 @@ class TestCohortViewer:
     def test_process(
         self,
         cohort_viewer: CohortViewer,
-        toy_cohort: Cohort,
+        suox_cohort: Cohort,
+        suox_mane_tx_id: str,
     ):
-        toy_transcript_id = "NM_123.1"
-
         report = cohort_viewer.process(
-            cohort=toy_cohort, transcript_id=toy_transcript_id
+            cohort=suox_cohort,
+            transcript_id=suox_mane_tx_id,
         )
 
-        buf = io.StringIO()
-        report.write(buf)
-        html = buf.getvalue()
-
-        # A dummy test for now.
-        assert len(html) != 0
+        with open(os.path.join("dev", "SUOX.cohort.html"), "w") as fh:
+            report.write(fh)


### PR DESCRIPTION
Add convenience methods for getting information for generating of summaries:

* count of males or count of deceased cohort members.
* indices of the significant HPO terms
* count of items that were filtered out by phenotype MT filter
