### PR TITLE
Report analysis errors

### DIFF
--- a/src/gpsea/analysis/__init__.py
+++ b/src/gpsea/analysis/__init__.py
@@ -1,4 +1,5 @@
 from ._base import (
+    AnalysisException,
     AnalysisResult,
     MonoPhenotypeAnalysisResult,
     MultiPhenotypeAnalysisResult,
@@ -7,6 +8,7 @@ from ._base import (
 )
 
 __all__ = [
+    "AnalysisException",
     "AnalysisResult",
     "MonoPhenotypeAnalysisResult",
     "MultiPhenotypeAnalysisResult",

--- a/src/gpsea/analysis/_base.py
+++ b/src/gpsea/analysis/_base.py
@@ -15,7 +15,10 @@ class StatisticResult:
     """
     `StatisticResult` reports result of a :class:`~gpsea.analysis.Statistic`.
 
-    It includes a statistic and a corresponding p value.
+    It includes a statistic (optional) and a corresponding p value.
+    The p value can be `NaN` if it is impossible to compute for a given dataset.
+
+    Raises an :class:`AssertionError` for an invalid input.
     """
 
     def __init__(
@@ -29,19 +32,21 @@ class StatisticResult:
         else:
             self._statistic = None
 
-        if isinstance(pval, float) and (math.isnan(pval) or 0.0 <= pval <= 1.0):
-            self._pval = float(pval)
-        else:
-            raise ValueError(
-                f"`pval` must be a float in range [0, 1] but it was {pval}"
-            )
-
+        assert isinstance(pval, float) and (math.isnan(pval) or 0.0 <= pval <= 1.0)
+        self._pval = float(pval)
+        
     @property
     def statistic(self) -> typing.Optional[float]:
+        """
+        Get a `float` with the test statistic or `None` if not available.
+        """
         return self._statistic
 
     @property
     def pval(self) -> float:
+        """
+        Get a p value (a value or a `NaN`).
+        """
         return self._pval
 
     def __eq__(self, value: object) -> bool:

--- a/src/gpsea/analysis/_base.py
+++ b/src/gpsea/analysis/_base.py
@@ -66,6 +66,33 @@ class StatisticResult:
         return f"StatisticResult(statistic={self._statistic}, pval={self._pval})"
 
 
+class AnalysisException(Exception):
+    """
+    Reports analysis issues that need user's attention.
+
+    To aid troubleshooting, the exception includes :attr:`~gpsea.analysis.AnalysisException.data` -
+    a mapping with any data that has been computed prior encountering the issues.
+    """
+    
+    def __init__(
+        self,
+        data: typing.Mapping[str, typing.Any],
+        *args,
+    ):
+        super().__init__(*args)
+        self._data = data
+
+    @property
+    def data(self) -> typing.Mapping[str, typing.Any]:
+        """
+        Get a mapping with (partial) data to aid troubleshooting.
+        """
+        return self._data
+    
+    def __repr__(self) -> str:
+        return f"AnalysisException(args={self.args}, data={self._data})"
+
+
 class Statistic(metaclass=abc.ABCMeta):
     """
     Mixin for classes that are used to compute a nominal p value for a genotype-phenotype association.
@@ -148,7 +175,7 @@ class MultiPhenotypeAnalysisResult(typing.Generic[P], AnalysisResult):
         statistic: Statistic,
         n_usable: typing.Sequence[int],
         all_counts: typing.Sequence[pd.DataFrame],
-        statistic_results: typing.Sequence[typing.Optional[StatisticResult]],
+        statistic_results: typing.Sequence[StatisticResult],
         corrected_pvals: typing.Optional[typing.Sequence[float]],
         mtc_correction: typing.Optional[str]
     ):

--- a/src/gpsea/analysis/predicate/phenotype/_pheno.py
+++ b/src/gpsea/analysis/predicate/phenotype/_pheno.py
@@ -230,17 +230,22 @@ class HpoPredicate(PhenotypePolyPredicate[hpotk.TermId]):
 
 class DiseasePresencePredicate(PhenotypePolyPredicate[hpotk.TermId]):
     """
-    `DiseasePresencePredicate` tests if the patient was diagnosed with a disease.
+    `DiseasePresencePredicate` tests if an individual was diagnosed with a disease.
 
-    The predicate tests if the patient's diseases include a disease ID formatted as a :class:`~hpotk.model.TermId`.
-
-    :param disease_id_query: the Disease ID to test
+    :param disease_id_query: a disease identifier formatted either as a CURIE `str` (e.g. ``OMIM:256000``)
+      or as a :class:`~hpotk.TermId`.
     """
 
-    def __init__(self, disease_id_query: hpotk.TermId):
-        self._query = validate_instance(
-            disease_id_query, hpotk.TermId, "disease_id_query"
-        )
+    def __init__(
+        self,
+        disease_id_query: typing.Union[str, hpotk.TermId],
+    ):
+        if isinstance(disease_id_query, str):
+            self._query = hpotk.TermId.from_curie(disease_id_query)
+        elif isinstance(disease_id_query, hpotk.TermId):
+            self._query = disease_id_query
+        else:
+            raise AssertionError
 
         self._diagnosis_present = PhenotypeCategorization(
             category=YES,

--- a/src/gpsea/analysis/temporal/stats/_api.py
+++ b/src/gpsea/analysis/temporal/stats/_api.py
@@ -23,6 +23,8 @@ class SurvivalStatistic(Statistic, metaclass=abc.ABCMeta):
         """
         Compute p value for the collection of survivals being sampled from
         the same source distribution.
+
+        Raises an error 
         """
         pass
 

--- a/tests/analysis/temporal/test_statistics.py
+++ b/tests/analysis/temporal/test_statistics.py
@@ -1,3 +1,4 @@
+import math
 import pytest
 
 from gpsea.analysis.temporal import Survival
@@ -6,9 +7,14 @@ from gpsea.analysis.temporal.stats import LogRankTest
 
 class TestLogRankTest:
 
-    def test_compute_pval(self):
-        statistic = LogRankTest()
+    @pytest.fixture(scope="class")
+    def statistic(self) -> LogRankTest:
+        return LogRankTest()
 
+    def test_compute_pval(
+        self,
+        statistic: LogRankTest,
+    ):
         values = (
             (
                 Survival(1.0, is_censored=True),
@@ -28,3 +34,25 @@ class TestLogRankTest:
         result = statistic.compute_pval(values)
 
         assert result.pval == pytest.approx(0.013383101)
+
+    def test_compute_pval_for_weird_dataset(
+        self,
+        statistic: LogRankTest,
+    ):
+        values = (
+            (
+                Survival(0.0, is_censored=False),
+                Survival(0.0, is_censored=False),
+                Survival(0.0, is_censored=False),
+                Survival(0.0, is_censored=False),
+            ),
+            (
+                Survival(0.0, is_censored=False),
+                Survival(0.0, is_censored=False),
+            ),
+        )
+        result = statistic.compute_pval(scores=values)
+
+        assert result.statistic is not None
+        assert math.isnan(result.statistic)
+        assert math.isnan(result.pval)

--- a/tests/analysis/test_analysis.py
+++ b/tests/analysis/test_analysis.py
@@ -1,0 +1,44 @@
+import typing
+
+import pytest
+
+from gpsea.analysis import StatisticResult
+
+
+class TestStatisticResult:
+
+    @pytest.mark.parametrize(
+        "statistic,pval",
+        [
+            (1.23, 0.5),
+            (1, 0.5),
+            (None, 0.5),
+        ],
+    )
+    def test_create_with_statistic(
+        self,
+        statistic: typing.Optional[typing.Union[int, float]],
+        pval: float,
+    ):
+        result = StatisticResult(statistic=statistic, pval=pval)
+
+        assert result.statistic == pytest.approx(statistic)
+        assert result.pval == pytest.approx(pval)
+
+    @pytest.mark.parametrize(
+        'statistic,pval',
+        [
+            ('12', .5),
+            (12, '.5'),
+            
+            (12, 1.00000001),
+            (12, -.00000001),
+        ]
+    )
+    def test_create_from_invalid(
+        self,
+        statistic: typing.Any,
+        pval: typing.Any,
+    ):
+        with pytest.raises(AssertionError):
+            StatisticResult(statistic=statistic, pval=pval)


### PR DESCRIPTION
Raise `AnalysisException` for weird datasets along with data computed so far to simplify troubleshooting.

For instance, Log rank test cannot compute a p value if survivals  are the same in all genotype subgroups. Here, an exception is raised to point out the issue and the survivals are reported.

Fixes #367 #371 