### PR TITLE
Ignore the inconsistent transcripts when getting transcripts for a gene from Variant Validator

### DIFF
--- a/src/gpsea/__init__.py
+++ b/src/gpsea/__init__.py
@@ -4,7 +4,7 @@ GPSEA is a library for analyzing genotype-phenotype correlations in cohorts of r
 
 __version__ = "0.7.2.dev0"
 
-_overwrite = True
+_overwrite = False
 """
 A private "hack" flag for regenerating documentation output (HTML fragments, figures).
 """

--- a/src/gpsea/preprocessing/__init__.py
+++ b/src/gpsea/preprocessing/__init__.py
@@ -10,7 +10,7 @@ from ._patient import PatientCreator, CohortCreator
 from ._phenopacket import PhenopacketVariantCoordinateFinder, PhenopacketPatientCreator, PhenopacketOntologyTermOnsetParser
 from ._uniprot import UniprotProteinMetadataService
 from ._vep import VepFunctionalAnnotator
-from ._vv import VVHgvsVariantCoordinateFinder, VVMultiCoordinateService
+from ._vv import VVHgvsVariantCoordinateFinder, VVMultiCoordinateService, VariantValidatorDecodeException
 
 __all__ = [
     'configure_caching_cohort_creator', 'configure_cohort_creator',
@@ -24,6 +24,6 @@ __all__ = [
     'TranscriptCoordinateService', 'GeneCoordinateService',
     'UniprotProteinMetadataService',
     'VepFunctionalAnnotator',
-    'VVHgvsVariantCoordinateFinder', 'VVMultiCoordinateService',
+    'VVHgvsVariantCoordinateFinder', 'VVMultiCoordinateService', 'VariantValidatorDecodeException',
     'DefaultImpreciseSvFunctionalAnnotator',
 ]

--- a/src/gpsea/preprocessing/_vv.py
+++ b/src/gpsea/preprocessing/_vv.py
@@ -340,7 +340,7 @@ class VVMultiCoordinateService(TranscriptCoordinateService, GeneCoordinateServic
             )
         
         # Adjust to strand, if necessary
-        if strand == Strand.POSITIVE:
+        if strand.is_positive():
             start = start_pos - 1  # Convert from 1-based to 0-based coordinate
             end = end_pos
         else:
@@ -358,7 +358,7 @@ class VVMultiCoordinateService(TranscriptCoordinateService, GeneCoordinateServic
         # Ensure the exons are sorted in ascending order
         exons = []
         for exon in sorted(genomic_span['exon_structure'], key=lambda exon_data: exon_data['exon_number']):
-            gen_start = exon['genomic_start'] - 1  # -1 to convert to 0-based coordinates.
+            gen_start = exon['genomic_start']
             gen_end = exon['genomic_end']
             gr = VVMultiCoordinateService._create_genomic_region(
                 contig=contig,

--- a/tests/preprocessing/data/vv_response/HGNC:12799.json
+++ b/tests/preprocessing/data/vv_response/HGNC:12799.json
@@ -1,0 +1,2689 @@
+{
+  "current_name": "WW domain containing oxidoreductase",
+  "current_symbol": "WWOX",
+  "hgnc": "HGNC:12799",
+  "previous_symbol": "",
+  "requested_symbol": "WWOX",
+  "transcripts": [
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": "CCDS42197.1",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "2"
+      },
+      "coding_end": 936,
+      "coding_start": 367,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 2, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78278719,
+          "exon_structure": [
+            {
+              "cigar": "473=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099413,
+              "transcript_end": 473,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 538,
+              "transcript_start": 474
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 596,
+              "transcript_start": 539
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 775,
+              "transcript_start": 597
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 882,
+              "transcript_start": 776
+            },
+            {
+              "cigar": "117=",
+              "exon_number": 6,
+              "genomic_end": 78278719,
+              "genomic_start": 78278603,
+              "transcript_end": 999,
+              "transcript_start": 883
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099413,
+          "total_exons": 6
+        },
+        "NC_000016.9": {
+          "end_position": 78312616,
+          "exon_structure": [
+            {
+              "cigar": "473=",
+              "exon_number": 1,
+              "genomic_end": 78133782,
+              "genomic_start": 78133310,
+              "transcript_end": 473,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78142384,
+              "genomic_start": 78142320,
+              "transcript_end": 538,
+              "transcript_start": 474
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78143732,
+              "genomic_start": 78143675,
+              "transcript_end": 596,
+              "transcript_start": 539
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78149051,
+              "genomic_start": 78148873,
+              "transcript_end": 775,
+              "transcript_start": 597
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78198186,
+              "genomic_start": 78198080,
+              "transcript_end": 882,
+              "transcript_start": 776
+            },
+            {
+              "cigar": "117=",
+              "exon_number": 6,
+              "genomic_end": 78312616,
+              "genomic_start": 78312500,
+              "transcript_end": 999,
+              "transcript_start": 883
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133310,
+          "total_exons": 6
+        }
+      },
+      "length": 1015,
+      "reference": "NM_130791.3",
+      "translation": "NP_570607.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "4"
+      },
+      "coding_end": 1305,
+      "coding_start": 400,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 4, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 79212667,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099654,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 2,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 290,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 3,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 469,
+              "transcript_start": 291
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 4,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 576,
+              "transcript_start": 470
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 5,
+              "genomic_end": 78386948,
+              "genomic_start": 78386860,
+              "transcript_end": 665,
+              "transcript_start": 577
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 6,
+              "genomic_end": 78425055,
+              "genomic_start": 78424870,
+              "transcript_end": 851,
+              "transcript_start": 666
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 7,
+              "genomic_end": 78432752,
+              "genomic_start": 78432488,
+              "transcript_end": 1116,
+              "transcript_start": 852
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 8,
+              "genomic_end": 79212667,
+              "genomic_start": 79211608,
+              "transcript_end": 2176,
+              "transcript_start": 1117
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 8
+        },
+        "NC_000016.9": {
+          "end_position": 79246564,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78133782,
+              "genomic_start": 78133551,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 2,
+              "genomic_end": 78143732,
+              "genomic_start": 78143675,
+              "transcript_end": 290,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 3,
+              "genomic_end": 78149051,
+              "genomic_start": 78148873,
+              "transcript_end": 469,
+              "transcript_start": 291
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 4,
+              "genomic_end": 78198186,
+              "genomic_start": 78198080,
+              "transcript_end": 576,
+              "transcript_start": 470
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 5,
+              "genomic_end": 78420845,
+              "genomic_start": 78420757,
+              "transcript_end": 665,
+              "transcript_start": 577
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 6,
+              "genomic_end": 78458952,
+              "genomic_start": 78458767,
+              "transcript_end": 851,
+              "transcript_start": 666
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 7,
+              "genomic_end": 78466649,
+              "genomic_start": 78466385,
+              "transcript_end": 1116,
+              "transcript_start": 852
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 8,
+              "genomic_end": 79246564,
+              "genomic_start": 79245505,
+              "transcript_end": 2176,
+              "transcript_start": 1117
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133551,
+          "total_exons": 8
+        }
+      },
+      "length": 2176,
+      "reference": "NM_001291997.2",
+      "translation": "NP_001278926.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "HPRD": "05501",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "2"
+      },
+      "coding_end": 1217,
+      "coding_start": 126,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 2, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78691292,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099654,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 641,
+              "transcript_start": 535
+            },
+            {
+              "cigar": "18=1X70=",
+              "exon_number": 6,
+              "genomic_end": 78386948,
+              "genomic_start": 78386860,
+              "transcript_end": 730,
+              "transcript_start": 642
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 7,
+              "genomic_end": 78425055,
+              "genomic_start": 78424870,
+              "transcript_end": 916,
+              "transcript_start": 731
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 8,
+              "genomic_end": 78432752,
+              "genomic_start": 78432488,
+              "transcript_end": 1181,
+              "transcript_start": 917
+            },
+            {
+              "cigar": "51=",
+              "exon_number": 9,
+              "genomic_end": 78691292,
+              "genomic_start": 78691242,
+              "transcript_end": 1232,
+              "transcript_start": 1182
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 9
+        }
+      },
+      "length": 1265,
+      "reference": "NM_018560.4",
+      "translation": "NP_061030.2"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "HPRD": "05501",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "5"
+      },
+      "coding_end": 767,
+      "coding_start": 126,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 5, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 79212667,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099654,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "27=1X48=",
+              "exon_number": 5,
+              "genomic_end": 78757015,
+              "genomic_start": 78756940,
+              "transcript_end": 610,
+              "transcript_start": 535
+            },
+            {
+              "cigar": "315=1X115=1X628=",
+              "exon_number": 6,
+              "genomic_end": 79212667,
+              "genomic_start": 79211608,
+              "transcript_end": 1670,
+              "transcript_start": 611
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 6
+        }
+      },
+      "length": 1693,
+      "reference": "NM_130792.1",
+      "translation": "NP_570608.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": "CCDS42196.1",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "1"
+      },
+      "coding_end": 1611,
+      "coding_start": 367,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 1, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 79212667,
+          "exon_structure": [
+            {
+              "cigar": "473=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099413,
+              "transcript_end": 473,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 538,
+              "transcript_start": 474
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 596,
+              "transcript_start": 539
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 775,
+              "transcript_start": 597
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 882,
+              "transcript_start": 776
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 6,
+              "genomic_end": 78386948,
+              "genomic_start": 78386860,
+              "transcript_end": 971,
+              "transcript_start": 883
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 7,
+              "genomic_end": 78425055,
+              "genomic_start": 78424870,
+              "transcript_end": 1157,
+              "transcript_start": 972
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 8,
+              "genomic_end": 78432752,
+              "genomic_start": 78432488,
+              "transcript_end": 1422,
+              "transcript_start": 1158
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 9,
+              "genomic_end": 79212667,
+              "genomic_start": 79211608,
+              "transcript_end": 2482,
+              "transcript_start": 1423
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099413,
+          "total_exons": 9
+        },
+        "NC_000016.9": {
+          "end_position": 79246564,
+          "exon_structure": [
+            {
+              "cigar": "473=",
+              "exon_number": 1,
+              "genomic_end": 78133782,
+              "genomic_start": 78133310,
+              "transcript_end": 473,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78142384,
+              "genomic_start": 78142320,
+              "transcript_end": 538,
+              "transcript_start": 474
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78143732,
+              "genomic_start": 78143675,
+              "transcript_end": 596,
+              "transcript_start": 539
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78149051,
+              "genomic_start": 78148873,
+              "transcript_end": 775,
+              "transcript_start": 597
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78198186,
+              "genomic_start": 78198080,
+              "transcript_end": 882,
+              "transcript_start": 776
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 6,
+              "genomic_end": 78420845,
+              "genomic_start": 78420757,
+              "transcript_end": 971,
+              "transcript_start": 883
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 7,
+              "genomic_end": 78458952,
+              "genomic_start": 78458767,
+              "transcript_end": 1157,
+              "transcript_start": 972
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 8,
+              "genomic_end": 78466649,
+              "genomic_start": 78466385,
+              "transcript_end": 1422,
+              "transcript_start": 1158
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 9,
+              "genomic_end": 79246564,
+              "genomic_start": 79245505,
+              "transcript_end": 2482,
+              "transcript_start": 1423
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133310,
+          "total_exons": 9
+        }
+      },
+      "length": 2505,
+      "reference": "NM_016373.3",
+      "translation": "NP_057457.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "5"
+      },
+      "coding_end": null,
+      "coding_start": null,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 5, non-coding RNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78278719,
+          "exon_structure": [
+            {
+              "cigar": "346=",
+              "exon_number": 1,
+              "genomic_end": 78099999,
+              "genomic_start": 78099654,
+              "transcript_end": 346,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 411,
+              "transcript_start": 347
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 469,
+              "transcript_start": 412
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 648,
+              "transcript_start": 470
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 755,
+              "transcript_start": 649
+            },
+            {
+              "cigar": "117=",
+              "exon_number": 6,
+              "genomic_end": 78278719,
+              "genomic_start": 78278603,
+              "transcript_end": 872,
+              "transcript_start": 756
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 6
+        },
+        "NC_000016.9": {
+          "end_position": 78312616,
+          "exon_structure": [
+            {
+              "cigar": "346=",
+              "exon_number": 1,
+              "genomic_end": 78133896,
+              "genomic_start": 78133551,
+              "transcript_end": 346,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78142384,
+              "genomic_start": 78142320,
+              "transcript_end": 411,
+              "transcript_start": 347
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78143732,
+              "genomic_start": 78143675,
+              "transcript_end": 469,
+              "transcript_start": 412
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78149051,
+              "genomic_start": 78148873,
+              "transcript_end": 648,
+              "transcript_start": 470
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78198186,
+              "genomic_start": 78198080,
+              "transcript_end": 755,
+              "transcript_start": 649
+            },
+            {
+              "cigar": "117=",
+              "exon_number": 6,
+              "genomic_end": 78312616,
+              "genomic_start": 78312500,
+              "transcript_end": 872,
+              "transcript_start": 756
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133551,
+          "total_exons": 6
+        }
+      },
+      "length": 872,
+      "reference": "NR_120436.2",
+      "translation": null
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "HPRD": "05501",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "3"
+      },
+      "coding_end": 236,
+      "coding_start": 126,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 3, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78100198,
+          "exon_structure": [
+            {
+              "cigar": "545=",
+              "exon_number": 1,
+              "genomic_end": 78100198,
+              "genomic_start": 78099654,
+              "transcript_end": 545,
+              "transcript_start": 1
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 1
+        }
+      },
+      "length": 545,
+      "reference": "NM_130844.1",
+      "translation": "NP_570859.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "5"
+      },
+      "coding_end": null,
+      "coding_start": null,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 5, non-coding RNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78278719,
+          "exon_structure": [
+            {
+              "cigar": "587=",
+              "exon_number": 1,
+              "genomic_end": 78099999,
+              "genomic_start": 78099413,
+              "transcript_end": 587,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 652,
+              "transcript_start": 588
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 710,
+              "transcript_start": 653
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 889,
+              "transcript_start": 711
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 996,
+              "transcript_start": 890
+            },
+            {
+              "cigar": "117=",
+              "exon_number": 6,
+              "genomic_end": 78278719,
+              "genomic_start": 78278603,
+              "transcript_end": 1113,
+              "transcript_start": 997
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099413,
+          "total_exons": 6
+        },
+        "NC_000016.9": {
+          "end_position": 78312616,
+          "exon_structure": [
+            {
+              "cigar": "587=",
+              "exon_number": 1,
+              "genomic_end": 78133896,
+              "genomic_start": 78133310,
+              "transcript_end": 587,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78142384,
+              "genomic_start": 78142320,
+              "transcript_end": 652,
+              "transcript_start": 588
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78143732,
+              "genomic_start": 78143675,
+              "transcript_end": 710,
+              "transcript_start": 653
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78149051,
+              "genomic_start": 78148873,
+              "transcript_end": 889,
+              "transcript_start": 711
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78198186,
+              "genomic_start": 78198080,
+              "transcript_end": 996,
+              "transcript_start": 890
+            },
+            {
+              "cigar": "117=",
+              "exon_number": 6,
+              "genomic_end": 78312616,
+              "genomic_start": 78312500,
+              "transcript_end": 1113,
+              "transcript_start": 997
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133310,
+          "total_exons": 6
+        }
+      },
+      "length": 1129,
+      "reference": "NR_120436.1",
+      "translation": null
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": "CCDS42197.1",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "2"
+      },
+      "coding_end": 695,
+      "coding_start": 126,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 2, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78278698,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099654,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 641,
+              "transcript_start": 535
+            },
+            {
+              "cigar": "96=",
+              "exon_number": 6,
+              "genomic_end": 78278698,
+              "genomic_start": 78278603,
+              "transcript_end": 737,
+              "transcript_start": 642
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 6
+        },
+        "NC_000016.9": {
+          "end_position": 78312595,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78133782,
+              "genomic_start": 78133551,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78142384,
+              "genomic_start": 78142320,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78143732,
+              "genomic_start": 78143675,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78149051,
+              "genomic_start": 78148873,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78198186,
+              "genomic_start": 78198080,
+              "transcript_end": 641,
+              "transcript_start": 535
+            },
+            {
+              "cigar": "96=",
+              "exon_number": 6,
+              "genomic_end": 78312595,
+              "genomic_start": 78312500,
+              "transcript_end": 737,
+              "transcript_start": 642
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133551,
+          "total_exons": 6
+        }
+      },
+      "length": 737,
+      "reference": "NM_130791.5",
+      "translation": "NP_570607.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "3"
+      },
+      "coding_end": null,
+      "coding_start": null,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 3, non-coding RNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78100199,
+          "exon_structure": [
+            {
+              "cigar": "787=",
+              "exon_number": 1,
+              "genomic_end": 78100199,
+              "genomic_start": 78099413,
+              "transcript_end": 787,
+              "transcript_start": 1
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099413,
+          "total_exons": 1
+        },
+        "NC_000016.9": {
+          "end_position": 78134096,
+          "exon_structure": [
+            {
+              "cigar": "787=",
+              "exon_number": 1,
+              "genomic_end": 78134096,
+              "genomic_start": 78133310,
+              "transcript_end": 787,
+              "transcript_start": 1
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133310,
+          "total_exons": 1
+        }
+      },
+      "length": 801,
+      "reference": "NR_120435.1",
+      "translation": null
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "3"
+      },
+      "coding_end": null,
+      "coding_start": null,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 3, non-coding RNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78100199,
+          "exon_structure": [
+            {
+              "cigar": "546=",
+              "exon_number": 1,
+              "genomic_end": 78100199,
+              "genomic_start": 78099654,
+              "transcript_end": 546,
+              "transcript_start": 1
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 1
+        },
+        "NC_000016.9": {
+          "end_position": 78134096,
+          "exon_structure": [
+            {
+              "cigar": "546=",
+              "exon_number": 1,
+              "genomic_end": 78134096,
+              "genomic_start": 78133551,
+              "transcript_end": 546,
+              "transcript_start": 1
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133551,
+          "total_exons": 1
+        }
+      },
+      "length": 546,
+      "reference": "NR_120435.2",
+      "translation": null
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": "CCDS42197.1",
+          "HPRD": "05501",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "2"
+      },
+      "coding_end": 919,
+      "coding_start": 350,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 2, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78278696,
+          "exon_structure": [
+            {
+              "cigar": "456=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099430,
+              "transcript_end": 456,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 521,
+              "transcript_start": 457
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 579,
+              "transcript_start": 522
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 758,
+              "transcript_start": 580
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 865,
+              "transcript_start": 759
+            },
+            {
+              "cigar": "94=",
+              "exon_number": 6,
+              "genomic_end": 78278696,
+              "genomic_start": 78278603,
+              "transcript_end": 959,
+              "transcript_start": 866
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099430,
+          "total_exons": 6
+        }
+      },
+      "length": 959,
+      "reference": "NM_130791.2",
+      "translation": "NP_570607.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": "CCDS42196.1",
+          "HPRD": "05501",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "1"
+      },
+      "coding_end": 1594,
+      "coding_start": 350,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 1, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 79212667,
+          "exon_structure": [
+            {
+              "cigar": "456=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099430,
+              "transcript_end": 456,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 521,
+              "transcript_start": 457
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 579,
+              "transcript_start": 522
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 758,
+              "transcript_start": 580
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 865,
+              "transcript_start": 759
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 6,
+              "genomic_end": 78386948,
+              "genomic_start": 78386860,
+              "transcript_end": 954,
+              "transcript_start": 866
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 7,
+              "genomic_end": 78425055,
+              "genomic_start": 78424870,
+              "transcript_end": 1140,
+              "transcript_start": 955
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 8,
+              "genomic_end": 78432752,
+              "genomic_start": 78432488,
+              "transcript_end": 1405,
+              "transcript_start": 1141
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 9,
+              "genomic_end": 79212667,
+              "genomic_start": 79211608,
+              "transcript_end": 2465,
+              "transcript_start": 1406
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099430,
+          "total_exons": 9
+        },
+        "NC_000016.9": {
+          "end_position": 79246564,
+          "exon_structure": [
+            {
+              "cigar": "456=",
+              "exon_number": 1,
+              "genomic_end": 78133782,
+              "genomic_start": 78133327,
+              "transcript_end": 456,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78142384,
+              "genomic_start": 78142320,
+              "transcript_end": 521,
+              "transcript_start": 457
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78143732,
+              "genomic_start": 78143675,
+              "transcript_end": 579,
+              "transcript_start": 522
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78149051,
+              "genomic_start": 78148873,
+              "transcript_end": 758,
+              "transcript_start": 580
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78198186,
+              "genomic_start": 78198080,
+              "transcript_end": 865,
+              "transcript_start": 759
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 6,
+              "genomic_end": 78420845,
+              "genomic_start": 78420757,
+              "transcript_end": 954,
+              "transcript_start": 866
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 7,
+              "genomic_end": 78458952,
+              "genomic_start": 78458767,
+              "transcript_end": 1140,
+              "transcript_start": 955
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 8,
+              "genomic_end": 78466649,
+              "genomic_start": 78466385,
+              "transcript_end": 1405,
+              "transcript_start": 1141
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 9,
+              "genomic_end": 79246564,
+              "genomic_start": 79245505,
+              "transcript_end": 2465,
+              "transcript_start": 1406
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133327,
+          "total_exons": 9
+        },
+        "NG_011698.1": {
+          "end_position": 1118014,
+          "exon_structure": [
+            {
+              "cigar": "456=",
+              "exon_number": 1,
+              "genomic_end": 5232,
+              "genomic_start": 4777,
+              "transcript_end": 456,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 13834,
+              "genomic_start": 13770,
+              "transcript_end": 521,
+              "transcript_start": 457
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 15182,
+              "genomic_start": 15125,
+              "transcript_end": 579,
+              "transcript_start": 522
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 20501,
+              "genomic_start": 20323,
+              "transcript_end": 758,
+              "transcript_start": 580
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 69636,
+              "genomic_start": 69530,
+              "transcript_end": 865,
+              "transcript_start": 759
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 6,
+              "genomic_end": 292295,
+              "genomic_start": 292207,
+              "transcript_end": 954,
+              "transcript_start": 866
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 7,
+              "genomic_end": 330402,
+              "genomic_start": 330217,
+              "transcript_end": 1140,
+              "transcript_start": 955
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 8,
+              "genomic_end": 338099,
+              "genomic_start": 337835,
+              "transcript_end": 1405,
+              "transcript_start": 1141
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 9,
+              "genomic_end": 1118014,
+              "genomic_start": 1116955,
+              "transcript_end": 2465,
+              "transcript_start": 1406
+            }
+          ],
+          "orientation": 1,
+          "start_position": 4777,
+          "total_exons": 9
+        }
+      },
+      "length": 2488,
+      "reference": "NM_016373.2",
+      "translation": "NP_057457.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": "CCDS42196.1",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": "MANE"
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": true,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": true,
+        "variant": "1"
+      },
+      "coding_end": 1370,
+      "coding_start": 126,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 1, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 79212667,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099654,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 641,
+              "transcript_start": 535
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 6,
+              "genomic_end": 78386948,
+              "genomic_start": 78386860,
+              "transcript_end": 730,
+              "transcript_start": 642
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 7,
+              "genomic_end": 78425055,
+              "genomic_start": 78424870,
+              "transcript_end": 916,
+              "transcript_start": 731
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 8,
+              "genomic_end": 78432752,
+              "genomic_start": 78432488,
+              "transcript_end": 1181,
+              "transcript_start": 917
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 9,
+              "genomic_end": 79212667,
+              "genomic_start": 79211608,
+              "transcript_end": 2241,
+              "transcript_start": 1182
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 9
+        },
+        "NC_000016.9": {
+          "end_position": 79246564,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78133782,
+              "genomic_start": 78133551,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78142384,
+              "genomic_start": 78142320,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78143732,
+              "genomic_start": 78143675,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78149051,
+              "genomic_start": 78148873,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78198186,
+              "genomic_start": 78198080,
+              "transcript_end": 641,
+              "transcript_start": 535
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 6,
+              "genomic_end": 78420845,
+              "genomic_start": 78420757,
+              "transcript_end": 730,
+              "transcript_start": 642
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 7,
+              "genomic_end": 78458952,
+              "genomic_start": 78458767,
+              "transcript_end": 916,
+              "transcript_start": 731
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 8,
+              "genomic_end": 78466649,
+              "genomic_start": 78466385,
+              "transcript_end": 1181,
+              "transcript_start": 917
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 9,
+              "genomic_end": 79246564,
+              "genomic_start": 79245505,
+              "transcript_end": 2241,
+              "transcript_start": 1182
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133551,
+          "total_exons": 9
+        },
+        "NG_011698.1": {
+          "end_position": 1118014,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 5232,
+              "genomic_start": 5001,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 13834,
+              "genomic_start": 13770,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 15182,
+              "genomic_start": 15125,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 20501,
+              "genomic_start": 20323,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 69636,
+              "genomic_start": 69530,
+              "transcript_end": 641,
+              "transcript_start": 535
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 6,
+              "genomic_end": 292295,
+              "genomic_start": 292207,
+              "transcript_end": 730,
+              "transcript_start": 642
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 7,
+              "genomic_end": 330402,
+              "genomic_start": 330217,
+              "transcript_end": 916,
+              "transcript_start": 731
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 8,
+              "genomic_end": 338099,
+              "genomic_start": 337835,
+              "transcript_end": 1181,
+              "transcript_start": 917
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 9,
+              "genomic_end": 1118014,
+              "genomic_start": 1116955,
+              "transcript_end": 2241,
+              "transcript_start": 1182
+            }
+          ],
+          "orientation": 1,
+          "start_position": 5001,
+          "total_exons": 9
+        }
+      },
+      "length": 2241,
+      "reference": "NM_016373.4",
+      "translation": "NP_057457.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": "CCDS42196.1",
+          "HPRD": "05501",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "1"
+      },
+      "coding_end": 1370,
+      "coding_start": 126,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 1, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 79212667,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099654,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 641,
+              "transcript_start": 535
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 6,
+              "genomic_end": 78386948,
+              "genomic_start": 78386860,
+              "transcript_end": 730,
+              "transcript_start": 642
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 7,
+              "genomic_end": 78425055,
+              "genomic_start": 78424870,
+              "transcript_end": 916,
+              "transcript_start": 731
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 8,
+              "genomic_end": 78432752,
+              "genomic_start": 78432488,
+              "transcript_end": 1181,
+              "transcript_start": 917
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 9,
+              "genomic_end": 79212667,
+              "genomic_start": 79211608,
+              "transcript_end": 2241,
+              "transcript_start": 1182
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 9
+        }
+      },
+      "length": 2264,
+      "reference": "NM_016373.1",
+      "translation": "NP_057457.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "HPRD": "05501",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "4"
+      },
+      "coding_end": 830,
+      "coding_start": 126,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 4, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 79212667,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099654,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 641,
+              "transcript_start": 535
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 6,
+              "genomic_end": 79212667,
+              "genomic_start": 79211608,
+              "transcript_end": 1701,
+              "transcript_start": 642
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 6
+        }
+      },
+      "length": 1724,
+      "reference": "NM_130788.1",
+      "translation": "NP_570604.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": "CCDS42197.1",
+          "HPRD": "05501",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "2"
+      },
+      "coding_end": 695,
+      "coding_start": 126,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 2, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78164289,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099654,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 641,
+              "transcript_start": 535
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 5
+        }
+      },
+      "length": 735,
+      "reference": "NM_130791.1",
+      "translation": "NP_570607.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "4"
+      },
+      "coding_end": 1546,
+      "coding_start": 641,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 4, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 79212667,
+          "exon_structure": [
+            {
+              "cigar": "473=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099413,
+              "transcript_end": 473,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 2,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 531,
+              "transcript_start": 474
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 3,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 710,
+              "transcript_start": 532
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 4,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 817,
+              "transcript_start": 711
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 5,
+              "genomic_end": 78386948,
+              "genomic_start": 78386860,
+              "transcript_end": 906,
+              "transcript_start": 818
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 6,
+              "genomic_end": 78425055,
+              "genomic_start": 78424870,
+              "transcript_end": 1092,
+              "transcript_start": 907
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 7,
+              "genomic_end": 78432752,
+              "genomic_start": 78432488,
+              "transcript_end": 1357,
+              "transcript_start": 1093
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 8,
+              "genomic_end": 79212667,
+              "genomic_start": 79211608,
+              "transcript_end": 2417,
+              "transcript_start": 1358
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099413,
+          "total_exons": 8
+        },
+        "NC_000016.9": {
+          "end_position": 79246564,
+          "exon_structure": [
+            {
+              "cigar": "473=",
+              "exon_number": 1,
+              "genomic_end": 78133782,
+              "genomic_start": 78133310,
+              "transcript_end": 473,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 2,
+              "genomic_end": 78143732,
+              "genomic_start": 78143675,
+              "transcript_end": 531,
+              "transcript_start": 474
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 3,
+              "genomic_end": 78149051,
+              "genomic_start": 78148873,
+              "transcript_end": 710,
+              "transcript_start": 532
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 4,
+              "genomic_end": 78198186,
+              "genomic_start": 78198080,
+              "transcript_end": 817,
+              "transcript_start": 711
+            },
+            {
+              "cigar": "89=",
+              "exon_number": 5,
+              "genomic_end": 78420845,
+              "genomic_start": 78420757,
+              "transcript_end": 906,
+              "transcript_start": 818
+            },
+            {
+              "cigar": "186=",
+              "exon_number": 6,
+              "genomic_end": 78458952,
+              "genomic_start": 78458767,
+              "transcript_end": 1092,
+              "transcript_start": 907
+            },
+            {
+              "cigar": "265=",
+              "exon_number": 7,
+              "genomic_end": 78466649,
+              "genomic_start": 78466385,
+              "transcript_end": 1357,
+              "transcript_start": 1093
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 8,
+              "genomic_end": 79246564,
+              "genomic_start": 79245505,
+              "transcript_end": 2417,
+              "transcript_start": 1358
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133310,
+          "total_exons": 8
+        }
+      },
+      "length": 2440,
+      "reference": "NM_001291997.1",
+      "translation": "NP_001278926.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": "CCDS42197.1",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "2"
+      },
+      "coding_end": 695,
+      "coding_start": 126,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 2, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78278719,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099654,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 641,
+              "transcript_start": 535
+            },
+            {
+              "cigar": "117=",
+              "exon_number": 6,
+              "genomic_end": 78278719,
+              "genomic_start": 78278603,
+              "transcript_end": 758,
+              "transcript_start": 642
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 6
+        },
+        "NC_000016.9": {
+          "end_position": 78312616,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78133782,
+              "genomic_start": 78133551,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78142384,
+              "genomic_start": 78142320,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78143732,
+              "genomic_start": 78143675,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78149051,
+              "genomic_start": 78148873,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78198186,
+              "genomic_start": 78198080,
+              "transcript_end": 641,
+              "transcript_start": 535
+            },
+            {
+              "cigar": "117=",
+              "exon_number": 6,
+              "genomic_end": 78312616,
+              "genomic_start": 78312500,
+              "transcript_end": 758,
+              "transcript_start": 642
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133551,
+          "total_exons": 6
+        }
+      },
+      "length": 758,
+      "reference": "NM_130791.4",
+      "translation": "NP_570607.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "HPRD": "05501",
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "3"
+      },
+      "coding_end": 1061,
+      "coding_start": 126,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 3, mRNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 79212667,
+          "exon_structure": [
+            {
+              "cigar": "232=",
+              "exon_number": 1,
+              "genomic_end": 78099885,
+              "genomic_start": 78099654,
+              "transcript_end": 232,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 297,
+              "transcript_start": 233
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 355,
+              "transcript_start": 298
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 534,
+              "transcript_start": 356
+            },
+            {
+              "cigar": "1060=",
+              "exon_number": 5,
+              "genomic_end": 79212667,
+              "genomic_start": 79211608,
+              "transcript_end": 1594,
+              "transcript_start": 535
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 5
+        }
+      },
+      "length": 1617,
+      "reference": "NM_130790.1",
+      "translation": "NP_570606.1"
+    },
+    {
+      "annotations": {
+        "chromosome": "16",
+        "db_xref": {
+          "CCDS": null,
+          "ensemblgene": null,
+          "hgnc": "HGNC:12799",
+          "ncbigene": "51741",
+          "select": false
+        },
+        "ensembl_select": false,
+        "mane_plus_clinical": false,
+        "mane_select": false,
+        "map": "16q23.1-q23.2",
+        "note": "WW domain containing oxidoreductase",
+        "refseq_select": false,
+        "variant": "5"
+      },
+      "coding_end": null,
+      "coding_start": null,
+      "description": "Homo sapiens WW domain containing oxidoreductase (WWOX), transcript variant 5, non-coding RNA",
+      "genomic_spans": {
+        "NC_000016.10": {
+          "end_position": 78278698,
+          "exon_structure": [
+            {
+              "cigar": "346=",
+              "exon_number": 1,
+              "genomic_end": 78099999,
+              "genomic_start": 78099654,
+              "transcript_end": 346,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78108487,
+              "genomic_start": 78108423,
+              "transcript_end": 411,
+              "transcript_start": 347
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78109835,
+              "genomic_start": 78109778,
+              "transcript_end": 469,
+              "transcript_start": 412
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78115154,
+              "genomic_start": 78114976,
+              "transcript_end": 648,
+              "transcript_start": 470
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78164289,
+              "genomic_start": 78164183,
+              "transcript_end": 755,
+              "transcript_start": 649
+            },
+            {
+              "cigar": "96=",
+              "exon_number": 6,
+              "genomic_end": 78278698,
+              "genomic_start": 78278603,
+              "transcript_end": 851,
+              "transcript_start": 756
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78099654,
+          "total_exons": 6
+        },
+        "NC_000016.9": {
+          "end_position": 78312595,
+          "exon_structure": [
+            {
+              "cigar": "346=",
+              "exon_number": 1,
+              "genomic_end": 78133896,
+              "genomic_start": 78133551,
+              "transcript_end": 346,
+              "transcript_start": 1
+            },
+            {
+              "cigar": "65=",
+              "exon_number": 2,
+              "genomic_end": 78142384,
+              "genomic_start": 78142320,
+              "transcript_end": 411,
+              "transcript_start": 347
+            },
+            {
+              "cigar": "58=",
+              "exon_number": 3,
+              "genomic_end": 78143732,
+              "genomic_start": 78143675,
+              "transcript_end": 469,
+              "transcript_start": 412
+            },
+            {
+              "cigar": "179=",
+              "exon_number": 4,
+              "genomic_end": 78149051,
+              "genomic_start": 78148873,
+              "transcript_end": 648,
+              "transcript_start": 470
+            },
+            {
+              "cigar": "107=",
+              "exon_number": 5,
+              "genomic_end": 78198186,
+              "genomic_start": 78198080,
+              "transcript_end": 755,
+              "transcript_start": 649
+            },
+            {
+              "cigar": "96=",
+              "exon_number": 6,
+              "genomic_end": 78312595,
+              "genomic_start": 78312500,
+              "transcript_end": 851,
+              "transcript_start": 756
+            }
+          ],
+          "orientation": 1,
+          "start_position": 78133551,
+          "total_exons": 6
+        }
+      },
+      "length": 851,
+      "reference": "NR_120436.3",
+      "translation": null
+    }
+  ]
+}

--- a/tests/preprocessing/test_vv.py
+++ b/tests/preprocessing/test_vv.py
@@ -11,16 +11,16 @@ from gpsea.preprocessing import VVMultiCoordinateService
 from gpsea.model.genome import transpose_coordinate
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def fpath_vv_response_dir(
     fpath_preprocessing_data_dir: str,
 ) -> str:
-    return os.path.join(fpath_preprocessing_data_dir, 'vv_response')
+    return os.path.join(fpath_preprocessing_data_dir, "vv_response")
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def vv_multi_coordinate_service(
-        genome_build: GenomeBuild,
+    genome_build: GenomeBuild,
 ) -> VVMultiCoordinateService:
     return VVMultiCoordinateService(genome_build)
 
@@ -32,21 +32,24 @@ class TestVVTranscriptCoordinateServiceProcessResponse:
 
     @pytest.mark.online
     @pytest.mark.parametrize(
-        'tx_id, contig, start, end, strand',
+        "tx_id, contig, start, end, strand",
         [
             # ANKRD11
-            ('NM_013275.6', '16', 847_784, 1_070_716, Strand.NEGATIVE),
+            ("NM_013275.6", "16", 847_784, 1_070_716, Strand.NEGATIVE),
             # MAPK8IP3
-            ('NM_001318852.2', '16', 1_706_194, 1_770_351, Strand.POSITIVE),
+            ("NM_001318852.2", "16", 1_706_194, 1_770_351, Strand.POSITIVE),
             # SUOX
-            ('NM_001032386.2', '12', 55_997_275, 56_005_525, Strand.POSITIVE),
-        ]
+            ("NM_001032386.2", "12", 55_997_275, 56_005_525, Strand.POSITIVE),
+        ],
     )
     def test_fetch__end_to_end(
-            self,
-            vv_multi_coordinate_service: VVMultiCoordinateService,
-            tx_id: str,
-            contig: str, start: int, end: int, strand: Strand,
+        self,
+        vv_multi_coordinate_service: VVMultiCoordinateService,
+        tx_id: str,
+        contig: str,
+        start: int,
+        end: int,
+        strand: Strand,
     ):
         tx_coordinates = vv_multi_coordinate_service.fetch(tx_id)
 
@@ -56,48 +59,55 @@ class TestVVTranscriptCoordinateServiceProcessResponse:
         assert tx_coordinates.region.end == end
         assert tx_coordinates.region.strand == strand
 
-    @pytest.mark.skip('Run to regenerate the response JSON files if the response format changed')
+    @pytest.mark.skip(
+        "Run to regenerate the response JSON files if the response format changed"
+    )
     @pytest.mark.parametrize(
-        'tx_id',
+        "tx_id",
         [
-            'NM_013275.6',  # ANKRD11
-            'NM_001318852.2',  # MAPK8IP3
-            'NM_001032386.2',  # SUOX
-        ]
+            "NM_013275.6",  # ANKRD11
+            "NM_001318852.2",  # MAPK8IP3
+            "NM_001032386.2",  # SUOX
+            "HGNC:12799",  # WWOX
+        ],
     )
     def test_get_response(
-            self,
-            tx_id: str,
-            vv_multi_coordinate_service: VVMultiCoordinateService,
-            fpath_vv_response_dir: str,
+        self,
+        tx_id: str,
+        vv_multi_coordinate_service: VVMultiCoordinateService,
+        fpath_vv_response_dir: str,
     ):
         response = vv_multi_coordinate_service.get_response(tx_id)
-        fpath_vv_response_json = os.path.join(fpath_vv_response_dir, f'{tx_id}.json')
-        with open(fpath_vv_response_json, 'w') as fh:
+        fpath_vv_response_json = os.path.join(fpath_vv_response_dir, f"{tx_id}.json")
+        with open(fpath_vv_response_json, "w") as fh:
             json.dump(
-                response, fh,
+                response,
+                fh,
                 indent=2,
             )
 
     @pytest.mark.parametrize(
-        'tx_id, contig, start, end, strand',
+        "tx_id, contig, start, end, strand",
         [
             # ANKRD11
-            ('NM_013275.6', '16', 847_784, 1_070_716, Strand.NEGATIVE),
+            ("NM_013275.6", "16", 847_784, 1_070_716, Strand.NEGATIVE),
             # MAPK8IP3
-            ('NM_001318852.2', '16', 1_706_194, 1_770_351, Strand.POSITIVE),
+            ("NM_001318852.2", "16", 1_706_194, 1_770_351, Strand.POSITIVE),
             # SUOX
-            ('NM_001032386.2', '12', 55_997_275, 56_005_525, Strand.POSITIVE),
-        ]
+            ("NM_001032386.2", "12", 55_997_275, 56_005_525, Strand.POSITIVE),
+        ],
     )
     def test_parse_response(
-            self,
-            fpath_vv_response_dir: str,
-            vv_multi_coordinate_service: VVMultiCoordinateService,
-            tx_id: str,
-            contig: str, start: int, end: int, strand: Strand,
+        self,
+        fpath_vv_response_dir: str,
+        vv_multi_coordinate_service: VVMultiCoordinateService,
+        tx_id: str,
+        contig: str,
+        start: int,
+        end: int,
+        strand: Strand,
     ):
-        fpath_vv_response_json = os.path.join(fpath_vv_response_dir, f'{tx_id}.json')
+        fpath_vv_response_json = os.path.join(fpath_vv_response_dir, f"{tx_id}.json")
         with open(fpath_vv_response_json) as fh:
             payload = json.load(fh)
 
@@ -109,6 +119,47 @@ class TestVVTranscriptCoordinateServiceProcessResponse:
         assert tx_coordinates.region.end == end
         assert tx_coordinates.region.strand == strand
 
+    @pytest.mark.parametrize(
+        "gene_id, tx_ids",
+        [
+            (
+                "HGNC:12799",
+                (
+                    "NM_130791.3",
+                    "NM_001291997.2",
+                    "NM_018560.4",
+                    "NM_130792.1",
+                    "NM_016373.3",
+                    "NM_130844.1",
+                    "NM_130791.5",
+                    "NM_130791.2",
+                    "NM_016373.2",
+                    "NM_016373.4",
+                    "NM_016373.1",
+                    "NM_130788.1",
+                    "NM_001291997.1",
+                    "NM_130791.4",
+                    "NM_130790.1",
+                ),
+            ),
+        ],
+    )
+    def test_parse_multiple(
+        self,
+        fpath_vv_response_dir: str,
+        vv_multi_coordinate_service: VVMultiCoordinateService,
+        gene_id: str,
+        tx_ids: typing.Sequence[str],
+    ):
+        fpath_vv_response_json = os.path.join(fpath_vv_response_dir, f"{gene_id}.json")
+        with open(fpath_vv_response_json) as fh:
+            payload = json.load(fh)
+
+        txs = vv_multi_coordinate_service.parse_multiple(payload)
+
+        assert len(txs) == len(tx_ids)
+        assert tuple(tx.identifier for tx in txs) == tx_ids
+
 
 @pytest.mark.online
 class TestVVTranscriptCoordinateServiceGeneralProperties:
@@ -119,58 +170,65 @@ class TestVVTranscriptCoordinateServiceGeneralProperties:
     We run these tests to check that the REST API format did not change.
     """
 
-    @pytest.fixture(scope='class')
+    @pytest.fixture(scope="class")
     def response(
-            self,
-            vv_multi_coordinate_service: VVMultiCoordinateService,
+        self,
+        vv_multi_coordinate_service: VVMultiCoordinateService,
     ) -> typing.Mapping[str, typing.Any]:
         # We test general properties of the response for a query for a transcript of *SUOX* gene
-        tx_id = 'NM_001032386.2'
+        tx_id = "NM_001032386.2"
         return vv_multi_coordinate_service.get_response(tx_id)
 
     def test_keys(
-            self,
-            response: typing.Mapping[str, typing.Any],
+        self,
+        response: typing.Mapping[str, typing.Any],
     ):
-        expected_keys = {"current_name", "current_symbol", "hgnc", "previous_symbol", "requested_symbol", "transcripts"}
+        expected_keys = {
+            "current_name",
+            "current_symbol",
+            "hgnc",
+            "previous_symbol",
+            "requested_symbol",
+            "transcripts",
+        }
         assert len(response.keys()) == len(expected_keys)
         assert all(key in expected_keys for key in response)
 
     def test_current_name(
-            self,
-            response: typing.Mapping[str, typing.Any],
+        self,
+        response: typing.Mapping[str, typing.Any],
     ):
         assert response.get("current_name") == "sulfite oxidase"
 
     def test_current_symbol(
-            self,
-            response: typing.Mapping[str, typing.Any],
+        self,
+        response: typing.Mapping[str, typing.Any],
     ):
         assert response.get("current_symbol") == "SUOX"
 
     def test_hgnc(
-            self,
-            response: typing.Mapping[str, typing.Any],
+        self,
+        response: typing.Mapping[str, typing.Any],
     ):
         expected = "HGNC:11460"
         assert response.get("hgnc") == expected
 
     def test_previous_symbol(
-            self,
-            response: typing.Mapping[str, typing.Any],
+        self,
+        response: typing.Mapping[str, typing.Any],
     ):
         assert response.get("previous_symbol") == ""
 
     def test_requested_symbol(
-            self,
-            response: typing.Mapping[str, typing.Any],
+        self,
+        response: typing.Mapping[str, typing.Any],
     ):
         # This is the transcript ID we requested from variantvalidator
         assert response.get("requested_symbol") == "NM_001032386.2"
 
     def test_transcripts(
-            self,
-            response: typing.Mapping[str, typing.Any],
+        self,
+        response: typing.Mapping[str, typing.Any],
     ):
         transcripts = response.get("transcripts")
 
@@ -178,14 +236,22 @@ class TestVVTranscriptCoordinateServiceGeneralProperties:
         assert len(transcripts) == 6
 
     def test_transcript_zero(
-            self,
-            response: typing.Mapping[str, typing.Any],
+        self,
+        response: typing.Mapping[str, typing.Any],
     ):
         transcripts = response.get("transcripts")
         t0 = transcripts[0]
         assert isinstance(t0, dict)
-        expected_keys = {'annotations', 'coding_end', 'coding_start', 'description', 'genomic_spans', 'length',
-                         'reference', 'translation'}
+        expected_keys = {
+            "annotations",
+            "coding_end",
+            "coding_start",
+            "description",
+            "genomic_spans",
+            "length",
+            "reference",
+            "translation",
+        }
         assert len(t0.keys()) == len(expected_keys)
         assert all(key in expected_keys for key in t0.keys())
 
@@ -209,21 +275,21 @@ class TestVVTranscriptCoordinateServiceGeneralProperties:
         assert hg38span.get("total_exons") == 4
 
 
-
-
 class TestVVTranscriptCoordinateServiceOffline:
     """
     Test processing of a cached JSON response to check if we parse the response well.
     """
 
     def test_ptpn11(
-            self, 
-            vv_multi_coordinate_service: VVMultiCoordinateService,
-            fpath_vv_response_dir: str,
-        ):
-        tx_id = 'NM_002834.5'
+        self,
+        vv_multi_coordinate_service: VVMultiCoordinateService,
+        fpath_vv_response_dir: str,
+    ):
+        tx_id = "NM_002834.5"
 
-        response_fpath = os.path.join(fpath_vv_response_dir, 'txid-NM_002834.5-PTPN11.json')
+        response_fpath = os.path.join(
+            fpath_vv_response_dir, "txid-NM_002834.5-PTPN11.json"
+        )
         response = load_response_json(response_fpath)
 
         tc = vv_multi_coordinate_service.parse_response(tx_id, response)
@@ -231,7 +297,7 @@ class TestVVTranscriptCoordinateServiceOffline:
         assert tc.identifier == tx_id
 
         tx_region = tc.region
-        assert tx_region.contig.name == '12'
+        assert tx_region.contig.name == "12"
         assert tx_region.start == 112_418_946
         assert tx_region.end == 112_509_918
         assert tx_region.strand == Strand.POSITIVE
@@ -250,13 +316,15 @@ class TestVVTranscriptCoordinateServiceOffline:
         assert tc.cds_end == 112_504_764
 
     def test_hbb(
-        self, 
+        self,
         vv_multi_coordinate_service: VVMultiCoordinateService,
         fpath_vv_response_dir: str,
     ):
-        tx_id = 'NM_000518.4'
+        tx_id = "NM_000518.4"
 
-        response_fpath = os.path.join(fpath_vv_response_dir, 'txid-NM_000518.4-HBB.json')
+        response_fpath = os.path.join(
+            fpath_vv_response_dir, "txid-NM_000518.4-HBB.json"
+        )
         response = load_response_json(response_fpath)
 
         tc = vv_multi_coordinate_service.parse_response(tx_id, response)
@@ -264,7 +332,7 @@ class TestVVTranscriptCoordinateServiceOffline:
         assert tc.identifier == tx_id
 
         tx_region = tc.region
-        assert tx_region.contig.name == '11'
+        assert tx_region.contig.name == "11"
         assert tx_region.start_on_strand(Strand.POSITIVE) == 5_225_465
         assert tx_region.end_on_strand(Strand.POSITIVE) == 5_227_071
         assert tx_region.strand == Strand.NEGATIVE
@@ -275,7 +343,6 @@ class TestVVTranscriptCoordinateServiceOffline:
         assert first.start == tx_region.start
         assert first.start_on_strand(Strand.POSITIVE) == 5_226_929
         assert first.end_on_strand(Strand.POSITIVE) == 5_227_071
-
 
         last = exons[-1]
         assert last.end == tx_region.end
@@ -292,19 +359,19 @@ class TestVVTranscriptCoordinateServiceOffline:
         assert tc.cds_start == 129_859_601
         assert tc.cds_end == 129_861_025
 
-    @pytest.mark.skip('Online tests are disabled by default')
+    @pytest.mark.online
     def test_fetch_ptpn11(
-        self, 
+        self,
         vv_multi_coordinate_service: VVMultiCoordinateService,
     ):
-        tx_id = 'NM_002834.5'
+        tx_id = "NM_002834.5"
 
         tc = vv_multi_coordinate_service.fetch(tx_id)
 
         assert tc.identifier == tx_id
 
         tx_region = tc.region
-        assert tx_region.contig.name == '12'
+        assert tx_region.contig.name == "12"
         assert tx_region.start == 112_418_946
         assert tx_region.end == 112_509_918
         assert tx_region.strand == Strand.POSITIVE
@@ -322,35 +389,34 @@ class TestVVTranscriptCoordinateServiceOffline:
         assert tc.cds_start == 112_419_111
         assert tc.cds_end == 112_504_764
 
-    @pytest.mark.skip('Run to manually regenerate SUOX MANE transcript JSON dump')
+    @pytest.mark.skip("Run to manually regenerate SUOX MANE transcript JSON dump")
     def test_fetch_suox(
         self,
         vv_multi_coordinate_service: VVMultiCoordinateService,
         fpath_suox_tx_coordinates: str,
     ):
-        tx_id = 'NM_001032386.2'
+        tx_id = "NM_001032386.2"
         response = vv_multi_coordinate_service.fetch(tx_id)
-        with open(fpath_suox_tx_coordinates, 'w') as fh:
+        with open(fpath_suox_tx_coordinates, "w") as fh:
             json.dump(response, fh, cls=GpseaJSONEncoder, indent=2)
 
 
 class TestVVMultiCoordinateService_as_GeneCoordinateService:
-
     def test_parse_hbb(
         self,
         vv_multi_coordinate_service: VVMultiCoordinateService,
         fpath_vv_response_dir: str,
     ):
-        response_fpath = os.path.join(fpath_vv_response_dir, 'gene-HBB.json')
+        response_fpath = os.path.join(fpath_vv_response_dir, "gene-HBB.json")
         response = load_response_json(response_fpath)
 
         txs = vv_multi_coordinate_service.parse_multiple(response=response)
-        
+
         assert len(txs) == 2
-        
+
         tx_ids = [txc.identifier for txc in txs]
-        assert tx_ids == ['NM_000518.5', 'NM_000518.4']
-        
+        assert tx_ids == ["NM_000518.5", "NM_000518.4"]
+
         preferred = [txc.is_preferred for txc in txs]
         assert preferred == [True, False]
 
@@ -359,28 +425,38 @@ class TestVVMultiCoordinateService_as_GeneCoordinateService:
         vv_multi_coordinate_service: VVMultiCoordinateService,
         fpath_vv_response_dir: str,
     ):
-        response_fpath = os.path.join(fpath_vv_response_dir, 'gene-PTPN11.json')
+        response_fpath = os.path.join(fpath_vv_response_dir, "gene-PTPN11.json")
         response = load_response_json(response_fpath)
 
         txs = vv_multi_coordinate_service.parse_multiple(response=response)
-        
+
         assert len(txs) == 9
-        
+
         tx_ids = [txc.identifier for txc in txs]
         assert tx_ids == [
-            'NM_001374625.1', 
-            'NM_001330437.2', 
-            'NM_080601.3', 
-            'NM_002834.5', 
-            'NM_002834.3', 
-            'NM_001330437.1', 
-            'NM_080601.2', 
-            'NM_080601.1', 
-            'NM_002834.4',
+            "NM_001374625.1",
+            "NM_001330437.2",
+            "NM_080601.3",
+            "NM_002834.5",
+            "NM_002834.3",
+            "NM_001330437.1",
+            "NM_080601.2",
+            "NM_080601.1",
+            "NM_002834.4",
         ]
-        
+
         preferred = [txc.is_preferred for txc in txs]
-        assert preferred == [False, False, False, True, False, False, False, False, False]
+        assert preferred == [
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ]
 
 
 def load_response_json(path: str):


### PR DESCRIPTION
Variant validator returns a weird transcript data for *WWOX*, with the CDS (695) ending beyond last exon end (641) for `NM_130791.1`.

We will ignore such transcripts when getting all transcripts for a gene.

Fixes #345