### PR TITLE
Removing erroneous X-axis label (# Codons)

### DIFF
--- a/src/gpsea/view/_protein_visualizer.py
+++ b/src/gpsea/view/_protein_visualizer.py
@@ -510,11 +510,7 @@ def draw_axes(ax, x_ticks, x_ticks_relative, y_ticks, max_marker_count,
             "# Variants", y_axis_x - 0.05, (y_axis_min_y + y_axis_max_y) / 2,
             fontsize=font_size, ha='center', va='center', rotation=90,
         )
-        draw_string(  # x axis label
-            ax,
-            "# Codons", (x_axis_min_x + x_axis_max_x) / 2, x_axis_y - 0.05,
-            fontsize=font_size, ha='center', va='center', rotation=0,
-                          )
+        # Note that we do not label the X-axis, the meaning will be obvious to users (amino acid residues)
         # draw y ticks
         draw_line(  # 0 tick
             ax,


### PR DESCRIPTION
The X-axis label was erroneous. Our users will know that the X axis represents amino acid residues, and nearly all of the plots you see like this do not have any label at all, so I am just removing it.