### PR TITLE
Simplify protein variant viewer, bugfixes

### DIFF
--- a/docs/user-guide/exploratory.rst
+++ b/docs/user-guide/exploratory.rst
@@ -148,7 +148,7 @@ This code will produce the following table on the basis of a cohort of individua
 with variants in the *TBX5* gene:
 
 >>> from gpsea.view import ProteinVariantViewer
->>> cpd_viewer = ProteinVariantViewer(tx_id=tx_id, protein_metadata=protein_meta)
+>>> cpd_viewer = ProteinVariantViewer(protein_metadata=protein_meta)
 >>> report = cpd_viewer.process(cohort)
 >>> report  # doctest: +SKIP
 

--- a/src/gpsea/view/_protein_visualizable.py
+++ b/src/gpsea/view/_protein_visualizable.py
@@ -39,6 +39,8 @@ class ProteinVisualizable:
         variant_regions_on_protein: typing.List[Region] = list()
         self._variant_effect = list()
         for tx_ann in transcript_annotations:
+            if tx_ann is None:
+                continue
             variant_effects = tx_ann.variant_effects
             if len(variant_effects) == 0:
                 continue
@@ -82,24 +84,19 @@ class ProteinVisualizable:
     def _get_tx_anns(
         variants: typing.Iterable[Variant],
         protein_id: str,
-    ) -> typing.Sequence[TranscriptAnnotation]:
+    ) -> typing.Sequence[typing.Optional[TranscriptAnnotation]]:
         """
         By default, the API returns transcript annotations for many transcripts.
         We would like to store the annotations only for our protein of interest (protein_id)
         """
         tx_anns = []
-        for i, v in enumerate(variants):
+        for v in variants:
             tx_ann = None
             for ann in v.tx_annotations:
                 if ann.protein_id is not None and ann.protein_id == protein_id:
                     tx_ann = ann
                     break
-            if tx_ann is None:
-                raise ValueError(
-                    f"The transcript annotation for {protein_id} was not found!"
-                )
-            else:
-                tx_anns.append(tx_ann)
+            tx_anns.append(tx_ann)
 
         return tx_anns
 

--- a/src/gpsea/view/_viewers.py
+++ b/src/gpsea/view/_viewers.py
@@ -522,12 +522,10 @@ class ProteinVariantViewer(BaseViewer):
     def __init__(
         self,
         protein_metadata: ProteinMetadata,
-        tx_id: str,
     ):
         super().__init__()
         self._cohort_template = self._environment.get_template("protein.html")
         self._protein_meta = protein_metadata
-        self._tx_id = tx_id
 
     def process(self, cohort: Cohort) -> GpseaReport:
         """
@@ -561,7 +559,7 @@ class ProteinVariantViewer(BaseViewer):
         # not over *unique* `VariantInfo`s
         for var in cohort.all_variants():
             target_annot = next(
-                (x for x in var.tx_annotations if x.transcript_id == self._tx_id), None
+                (x for x in var.tx_annotations if x.protein_id == self._protein_meta.protein_id), None
             )
             if target_annot is None:
                 # structural variants do not have a transcript id, and we skip them

--- a/tests/view/test_protein_visualizer.py
+++ b/tests/view/test_protein_visualizer.py
@@ -1,13 +1,10 @@
-import io
 import matplotlib.pyplot as plt
 import pytest
 
 from gpsea.model import Cohort, ProteinMetadata
 from gpsea.view import (
-    GpseaReport,
     configure_default_protein_visualizer,
     BaseProteinVisualizer,
-    ProteinVariantViewer,
 )
 
 
@@ -32,19 +29,3 @@ class TestProteinVisualizer:
 
         fig.savefig("protein.png")
 
-    def test_protein_viewable(
-        self,
-        suox_cohort: Cohort,
-        suox_protein_metadata: ProteinMetadata,
-    ):
-        protein_viewable = ProteinVariantViewer(
-            protein_metadata=suox_protein_metadata,
-        )
-        report = protein_viewable.process(suox_cohort)
-        assert isinstance(report, GpseaReport)
-
-        buf = io.StringIO()
-        report.write(buf)
-        val = buf.getvalue()
-
-        assert "gpsea-body" in val

--- a/tests/view/test_protein_visualizer.py
+++ b/tests/view/test_protein_visualizer.py
@@ -36,10 +36,9 @@ class TestProteinVisualizer:
         self,
         suox_cohort: Cohort,
         suox_protein_metadata: ProteinMetadata,
-        suox_mane_tx_id: str,
     ):
         protein_viewable = ProteinVariantViewer(
-            protein_metadata=suox_protein_metadata, tx_id=suox_mane_tx_id
+            protein_metadata=suox_protein_metadata,
         )
         report = protein_viewable.process(suox_cohort)
         assert isinstance(report, GpseaReport)

--- a/tests/view/test_viewers.py
+++ b/tests/view/test_viewers.py
@@ -1,15 +1,18 @@
+import io
 import os
 
 import hpotk
 import pytest
 
 from gpsea.analysis.pcats import HpoTermAnalysisResult
-from gpsea.model import Cohort
+from gpsea.model import Cohort, ProteinMetadata
 from gpsea.view import (
     CohortViewer,
     CohortVariantViewer,
+    GpseaReport,
     MtcStatsViewer,
 )
+from gpsea.view._viewers import ProteinVariantViewer
 
 
 @pytest.mark.skip("Just for manual testing and debugging")
@@ -79,3 +82,29 @@ class TestMtcStatsViewer:
         report = stats_viewer.process(result=hpo_term_analysis_result)
         with open("mtc_stats.html", "w") as fh:
             report.write(fh)
+
+
+class TestProteinVariantViewer:
+
+    @pytest.fixture(scope="class")
+    def protein_variant_viewer(
+        self,
+        suox_protein_metadata: ProteinMetadata,
+    ) -> ProteinVariantViewer:
+        return ProteinVariantViewer(
+            protein_metadata=suox_protein_metadata,
+        )
+
+    def test_process(
+        self,
+        suox_cohort: Cohort,
+        protein_variant_viewer: ProteinVariantViewer,
+    ):
+        report = protein_variant_viewer.process(suox_cohort)
+        assert isinstance(report, GpseaReport)
+
+        buf = io.StringIO()
+        report.write(buf)
+        val = buf.getvalue()
+
+        assert "gpsea-body" in val

--- a/tests/view/test_viewers.py
+++ b/tests/view/test_viewers.py
@@ -1,21 +1,14 @@
-import math
 import os
 
 import hpotk
-import pandas as pd
 import pytest
 
-from gpsea.analysis import StatisticResult
 from gpsea.analysis.pcats import HpoTermAnalysisResult
-from gpsea.analysis.pcats.stats import FisherExactTest
-from gpsea.analysis.clf import GenotypeClassifier, HpoClassifier
-from gpsea.analysis.mtc_filter import PhenotypeMtcResult
 from gpsea.model import Cohort
 from gpsea.view import (
     CohortViewer,
     CohortVariantViewer,
     MtcStatsViewer,
-    summarize_hpo_analysis,
 )
 
 


### PR DESCRIPTION
We should not need `tx_id` to show protein information, protein ID should be enough.

Clean up some `gpsea.view` tests.