### PR TITLE
Add numtest and use doctest.ELLIPSIS_MARKER to fix doctest errors when doing floating point number comparisons

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,9 @@ import doctest
 import os
 import sys
 
+# use numtest to allow floating point comparisons
+doctest.ELLIPSIS_MARKER = '...'
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,8 +3,6 @@ import doctest
 import os
 import sys
 
-# use numtest to allow floating point comparisons
-doctest.ELLIPSIS_MARKER = '...'
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/user-guide/analyses/phenotype-scores.rst
+++ b/docs/user-guide/analyses/phenotype-scores.rst
@@ -39,7 +39,7 @@ This is a non-parametric test that compares the medians of the two classes to de
 >>> r = stats.mannwhitneyu(x=class1, y=class2, alternative = 'two-sided')
 >>> p_value = r.pvalue
 >>> float(p_value)
-6.348081479150e...-06
+6.348081479150...e-06
 
 
 p value of `6.348081479150e-06` suggests a significant difference between the classes.

--- a/docs/user-guide/analyses/phenotype-scores.rst
+++ b/docs/user-guide/analyses/phenotype-scores.rst
@@ -38,11 +38,11 @@ This is a non-parametric test that compares the medians of the two classes to de
 >>> class2 = [4, 5, 3, 4, 3, 3, 3, 4, 4, 5, 5, 2, 3, 0, 3, 5, 2, 3]
 >>> r = stats.mannwhitneyu(x=class1, y=class2, alternative = 'two-sided')
 >>> p_value = r.pvalue
->>> float(p_value)
-6.348081479150902e-06
+>>> float(p_value) # doctest: +ELLIPSIS
+6.348081479150...e-06
 
 
-p value of `6.348081479150901e-06` suggests a significant difference between the classes.
+p value of `6.348081479150e-06` suggests a significant difference between the classes.
 
 
 ****************
@@ -73,7 +73,7 @@ from a `JSON file <https://github.com/monarch-initiative/gpsea/tree/main/docs/co
 The cohort was prepared from phenopackets as described in :ref:`create-a-cohort` section,
 and then serialized as a JSON file following the instructions in :ref:`cohort-persistence` section.
 
-.. 
+..
    Prepare the JSON file by running the tests in `tests/tests/test_generate_doc_cohorts.py`.
 
 >>> import json
@@ -99,8 +99,8 @@ Genotype predicate
 ------------------
 
 *Jordan et al.* compare phenotype of individuals harboring point mutations
-with the individuals carrying loss of function mutations. 
-Let's create a predicate for testing if the variant 
+with the individuals carrying loss of function mutations.
+Let's create a predicate for testing if the variant
 is a point mutation or a loss of function mutation.
 
 In this example, the point mutation is a mutation that meets the following conditions:
@@ -158,7 +158,7 @@ As far as GPSEA framework is concerned, the phenotype score must be a floating p
 or a `NaN` value if the score cannot be computed for an individual.
 This is the essence of the :class:`~gpsea.analysis.pscore.PhenotypeScorer` class.
 
-GPSEA ships with several builtin phenotype scorers which can be used as  
+GPSEA ships with several builtin phenotype scorers which can be used as
 
 +------------------------------------------------------------+---------------------------------------------+
 | Name                                                       | Description                                 |
@@ -189,7 +189,7 @@ from the following 5 categories:
 
 For example, an individual with a congenital heart defect would be assigned a score of `1`,
 an individual with congenital heart defect and a renal anomaly would be assigned a score of `2`,
-and so on. If an individual had two heart defects (e.g., atrial septal defect and ventricular septal defect), 
+and so on. If an individual had two heart defects (e.g., atrial septal defect and ventricular septal defect),
 a score of 1 (not 2) would be assigned for the heart defect category.
 
 The :class:`~gpsea.analysis.pscore.CountingPhenotypeScorer` automatizes this scoring method
@@ -245,7 +245,7 @@ We will put the final analysis together into :class:`~gpsea.analysis.pscore.Phen
 
 >>> from gpsea.analysis.pscore import PhenotypeScoreAnalysis
 >>> score_analysis = PhenotypeScoreAnalysis(
-...     score_statistic=score_statistic,   
+...     score_statistic=score_statistic,
 ... )
 
 
@@ -265,8 +265,8 @@ In case of the *RERE* cohort, the analysis shows a significant difference
 between the number of structural defects in individuals
 with point vs. loss-of-function mutations.
 
->>> result.pval
-0.012074957610483744
+>>> result.pval # doctest: +ELLIPSIS
+0.0120749576...
 
 
 To explore further, we can access a data frame with genotype categories and phenotype counts:

--- a/docs/user-guide/analyses/phenotype-scores.rst
+++ b/docs/user-guide/analyses/phenotype-scores.rst
@@ -38,8 +38,8 @@ This is a non-parametric test that compares the medians of the two classes to de
 >>> class2 = [4, 5, 3, 4, 3, 3, 3, 4, 4, 5, 5, 2, 3, 0, 3, 5, 2, 3]
 >>> r = stats.mannwhitneyu(x=class1, y=class2, alternative = 'two-sided')
 >>> p_value = r.pvalue
->>> float(p_value) # doctest: +ELLIPSIS
-6.348081479150...e-06
+>>> float(p_value)
+6.348081479150e...-06
 
 
 p value of `6.348081479150e-06` suggests a significant difference between the classes.

--- a/docs/user-guide/analyses/survival.rst
+++ b/docs/user-guide/analyses/survival.rst
@@ -27,7 +27,7 @@ from a `JSON file <https://github.com/monarch-initiative/gpsea/tree/main/docs/co
 The cohort was prepared from phenopackets as described in :ref:`create-a-cohort` section,
 and then serialized as a JSON file following the instructions in :ref:`cohort-persistence` section.
 
-.. 
+..
    Prepare the JSON file by running the tests in `tests/tests/test_generate_doc_cohorts.py`.
 
 >>> import json
@@ -127,7 +127,7 @@ We execute the analysis by running
 ... )
 
 >>> result.pval
-0.06200425830044376
+0.062004258300...
 
 
 Kaplan-Meier curves
@@ -145,7 +145,7 @@ We can plot Kaplan-Meier curves:
 ... )
 >>> _ = ax.xaxis.set(
 ...     # Show X axis in years ...
-...     major_formatter=mpl.ticker.FuncFormatter(lambda x, pos: f"{x / Age.DAYS_IN_YEAR:.0f}"),  
+...     major_formatter=mpl.ticker.FuncFormatter(lambda x, pos: f"{x / Age.DAYS_IN_YEAR:.0f}"),
 ...     # ... with a tick for every decade
 ...     major_locator=mpl.ticker.MultipleLocator(10 * Age.DAYS_IN_YEAR),
 ... )
@@ -164,7 +164,7 @@ We can plot Kaplan-Meier curves:
    :hide:
 
    >>> if _overwrite: fig.savefig('docs/user-guide/analyses/report/umod_km_curves.png')
-   
+
 
 Raw data
 --------
@@ -174,7 +174,7 @@ The `result` includes the survival values for all cohort members:
 >>> survivals = result.data.sort_index()
 >>> survivals.head()  # doctest: +NORMALIZE_WHITESPACE
                           genotype    phenotype
-patient_id                                                                        
+patient_id
 AII.1[PMID_22034507_AII_1]       0    Survival(value=18262.5, is_censored=True)
 AII.2[PMID_22034507_AII_2]       0    None
 AII.3[PMID_22034507_AII_3]       0    Survival(value=16436.25, is_censored=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
     "pytest>=7.0.0,<8.0.0",
-    "pytest-cov",
-    "numtest"
+    "pytest-cov"
 ]
 docs = [
     "sphinx>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,13 @@ dynamic = ["version"]
 test = [
     "pytest>=7.0.0,<8.0.0",
     "pytest-cov",
+    "numtest"
 ]
 docs = [
     "sphinx>=7.0.0",
     "sphinx-rtd-theme>=1.3.0",
     "sphinx-rtd-dark-mode>=1.3.0",
-    "sphinx-copybutton>=0.5.0", 
+    "sphinx-copybutton>=0.5.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
doctests in survival.rst and phenotype_scores.rst are failing for me on my Macbook M1 MacOS v12.5

```
FAILED               [  2%]
docs/user-guide/analyses/survival.rst:0 ([doctest] survival.rst)
120 
121 We execute the analysis by running
122 
123 >>> result = survival_analysis.compare_genotype_vs_survival(
124 ...     cohort=cohort,
125 ...     gt_clf=gt_clf,
126 ...     endpoint=endpoint,
127 ... )
128 
129 >>> result.pval
Expected:
    0.06200425830044376
Got:
    0.06200425830044377

/Users/jtr4v/PythonProject/gpsea/docs/user-guide/analyses/survival.rst:129: DocTestFailure
```

This PR adds numtest as a test dependency and then uses ELLIPSIS_MARKER to allow approximate comparisons