### PR TITLE
Disable `HMF01`

### DIFF
--- a/docs/report/tbx5_all_variants.html
+++ b/docs/report/tbx5_all_variants.html
@@ -188,14 +188,6 @@
       
       <tr>
         <td>5</td>
-        <td>12_114403792_114403792_C_CG</td>
-        <td>c.106_107insC (p.Ser36ThrfsTer25)</td>
-        <td>2</td>
-        <td>frameshift</td>
-      </tr>
-      
-      <tr>
-        <td>5</td>
         <td>12_114398682_114398682_C_CG</td>
         <td>c.400dup (p.Arg134ProfsTer49)</td>
         <td>5</td>
@@ -203,10 +195,34 @@
       </tr>
       
       <tr>
+        <td>5</td>
+        <td>12_114403792_114403792_C_CG</td>
+        <td>c.106_107insC (p.Ser36ThrfsTer25)</td>
+        <td>2</td>
+        <td>frameshift</td>
+      </tr>
+      
+      <tr>
+        <td>4</td>
+        <td>12_114385474_114385474_A_G</td>
+        <td>c.755+2T>C (-)</td>
+        <td>-</td>
+        <td>splice donor</td>
+      </tr>
+      
+      <tr>
         <td>4</td>
         <td>12_114403798_114403798_G_GC</td>
         <td>c.100dup (p.Ala34GlyfsTer27)</td>
         <td>2</td>
+        <td>frameshift</td>
+      </tr>
+      
+      <tr>
+        <td>4</td>
+        <td>12_114398656_114398656_C_CG</td>
+        <td>c.426dup (p.Ala143ArgfsTer40)</td>
+        <td>5</td>
         <td>frameshift</td>
       </tr>
       
@@ -227,27 +243,11 @@
       </tr>
       
       <tr>
-        <td>4</td>
-        <td>12_114385474_114385474_A_G</td>
-        <td>c.755+2T>C (-)</td>
-        <td>-</td>
-        <td>splice donor</td>
-      </tr>
-      
-      <tr>
-        <td>4</td>
-        <td>12_114398656_114398656_C_CG</td>
-        <td>c.426dup (p.Ala143ArgfsTer40)</td>
-        <td>5</td>
-        <td>frameshift</td>
-      </tr>
-      
-      <tr>
         <td>3</td>
-        <td>12_114403798_114403799_GC_G</td>
-        <td>c.100del (p.Ala34ProfsTer32)</td>
-        <td>2</td>
-        <td>frameshift</td>
+        <td>12_114366366_114366366_T_A</td>
+        <td>c.781A>T (p.Ser261Cys)</td>
+        <td>8</td>
+        <td>missense</td>
       </tr>
       
       <tr>
@@ -256,14 +256,6 @@
         <td>c.262A>T (p.Lys88Ter)</td>
         <td>4</td>
         <td>stop gained</td>
-      </tr>
-      
-      <tr>
-        <td>3</td>
-        <td>12_114401827_114401827_T_A</td>
-        <td>c.241A>T (p.Arg81Trp)</td>
-        <td>3</td>
-        <td>missense, splice region</td>
       </tr>
       
       <tr>
@@ -284,10 +276,10 @@
       
       <tr>
         <td>3</td>
-        <td>12_114366366_114366366_T_A</td>
-        <td>c.781A>T (p.Ser261Cys)</td>
-        <td>8</td>
-        <td>missense</td>
+        <td>12_114403798_114403799_GC_G</td>
+        <td>c.100del (p.Ala34ProfsTer32)</td>
+        <td>2</td>
+        <td>frameshift</td>
       </tr>
       
       <tr>
@@ -299,27 +291,11 @@
       </tr>
       
       <tr>
-        <td>2</td>
-        <td>12_114366207_114366208_GC_G</td>
-        <td>c.939del (p.Gln315ArgfsTer79)</td>
-        <td>8</td>
-        <td>frameshift</td>
-      </tr>
-      
-      <tr>
-        <td>2</td>
-        <td>12_114403754_114403754_G_T</td>
-        <td>c.145C>A (p.Gln49Lys)</td>
-        <td>2</td>
+        <td>3</td>
+        <td>12_114401827_114401827_T_A</td>
+        <td>c.241A>T (p.Arg81Trp)</td>
+        <td>3</td>
         <td>missense, splice region</td>
-      </tr>
-      
-      <tr>
-        <td>2</td>
-        <td>12_114385521_114385521_C_G</td>
-        <td>c.710G>C (p.Arg237Pro)</td>
-        <td>7</td>
-        <td>missense</td>
       </tr>
       
       <tr>
@@ -332,18 +308,34 @@
       
       <tr>
         <td>2</td>
-        <td>12_114385550_114385550_A_AATTATTCTCAG</td>
-        <td>c.680_681insCTGAGAATAAT (p.Ile227_Glu228insTer)</td>
-        <td>7</td>
-        <td>inframe insertion, stop retainined</td>
-      </tr>
-      
-      <tr>
-        <td>2</td>
         <td>12_114366274_114366274_G_T</td>
         <td>c.873C>A (p.Tyr291Ter)</td>
         <td>8</td>
         <td>stop gained</td>
+      </tr>
+      
+      <tr>
+        <td>2</td>
+        <td>12_114385521_114385521_C_G</td>
+        <td>c.710G>C (p.Arg237Pro)</td>
+        <td>7</td>
+        <td>missense</td>
+      </tr>
+      
+      <tr>
+        <td>2</td>
+        <td>12_114366207_114366208_GC_G</td>
+        <td>c.939del (p.Gln315ArgfsTer79)</td>
+        <td>8</td>
+        <td>frameshift</td>
+      </tr>
+      
+      <tr>
+        <td>2</td>
+        <td>12_114394762_114394763_CA_C</td>
+        <td>c.641del (p.Val214GlyfsTer12)</td>
+        <td>6</td>
+        <td>frameshift</td>
       </tr>
       
       <tr>
@@ -356,10 +348,18 @@
       
       <tr>
         <td>2</td>
-        <td>12_114394762_114394763_CA_C</td>
-        <td>c.641del (p.Val214GlyfsTer12)</td>
-        <td>6</td>
-        <td>frameshift</td>
+        <td>12_114385550_114385550_A_AATTATTCTCAG</td>
+        <td>c.680_681insCTGAGAATAAT (p.Ile227_Glu228insTer)</td>
+        <td>7</td>
+        <td>inframe insertion, stop retainined</td>
+      </tr>
+      
+      <tr>
+        <td>2</td>
+        <td>12_114403754_114403754_G_T</td>
+        <td>c.145C>A (p.Gln49Lys)</td>
+        <td>2</td>
+        <td>missense, splice region</td>
       </tr>
       
       <tr>
@@ -380,25 +380,65 @@
       
       <tr>
         <td>1</td>
-        <td>12_114399594_114399594_A_C</td>
-        <td>c.281T>G (p.Leu94Arg)</td>
+        <td>12_114401907_114401907_A_G</td>
+        <td>c.161T>C (p.Ile54Thr)</td>
+        <td>3</td>
+        <td>missense</td>
+      </tr>
+      
+      <tr>
+        <td>1</td>
+        <td>12_114401846_114401846_C_G</td>
+        <td>c.222G>C (p.Met74Ile)</td>
+        <td>3</td>
+        <td>missense</td>
+      </tr>
+      
+      <tr>
+        <td>1</td>
+        <td>12_114356064_114356065_TA_T</td>
+        <td>c.1024del (p.Tyr342ThrfsTer52)</td>
+        <td>9</td>
+        <td>frameshift</td>
+      </tr>
+      
+      <tr>
+        <td>1</td>
+        <td>12_114355784_114355785_CA_C</td>
+        <td>c.1304del (p.Leu435ArgfsTer147)</td>
+        <td>9</td>
+        <td>frameshift</td>
+      </tr>
+      
+      <tr>
+        <td>1</td>
+        <td>12_114399559_114399559_T_C</td>
+        <td>c.316A>G (p.Ile106Val)</td>
         <td>4</td>
         <td>missense</td>
       </tr>
       
       <tr>
         <td>1</td>
-        <td>12_114366348_114366349_CT_C</td>
-        <td>c.798del (p.Val267TrpfsTer127)</td>
-        <td>8</td>
+        <td>12_114398708_114398709_GC_G</td>
+        <td>c.374del (p.Gly125AlafsTer25)</td>
+        <td>5</td>
         <td>frameshift</td>
       </tr>
       
       <tr>
         <td>1</td>
-        <td>12_114403859_114403859_G_T</td>
-        <td>c.40C>A (p.Pro14Thr)</td>
-        <td>2</td>
+        <td>12_114355755_114355756_TG_T</td>
+        <td>c.1333del (p.His445MetfsTer137)</td>
+        <td>9</td>
+        <td>frameshift</td>
+      </tr>
+      
+      <tr>
+        <td>1</td>
+        <td>12_114394820_114394820_C_G</td>
+        <td>c.584G>C (p.Gly195Ala)</td>
+        <td>6</td>
         <td>missense</td>
       </tr>
       
@@ -412,17 +452,25 @@
       
       <tr>
         <td>1</td>
-        <td>12_114401907_114401907_A_G</td>
-        <td>c.161T>C (p.Ile54Thr)</td>
-        <td>3</td>
+        <td>12_114399594_114399594_A_C</td>
+        <td>c.281T>G (p.Leu94Arg)</td>
+        <td>4</td>
         <td>missense</td>
       </tr>
       
       <tr>
         <td>1</td>
-        <td>12_114394820_114394820_C_G</td>
-        <td>c.584G>C (p.Gly195Ala)</td>
-        <td>6</td>
+        <td>12_114401921_114401921_C_G</td>
+        <td>c.148-1G>C (-)</td>
+        <td>-</td>
+        <td>splice acceptor</td>
+      </tr>
+      
+      <tr>
+        <td>1</td>
+        <td>12_114399622_114399622_G_T</td>
+        <td>c.253C>A (p.Pro85Thr)</td>
+        <td>4</td>
         <td>missense</td>
       </tr>
       
@@ -444,58 +492,10 @@
       
       <tr>
         <td>1</td>
-        <td>12_114398708_114398709_GC_G</td>
-        <td>c.374del (p.Gly125AlafsTer25)</td>
-        <td>5</td>
-        <td>frameshift</td>
-      </tr>
-      
-      <tr>
-        <td>1</td>
-        <td>12_114356064_114356065_TA_T</td>
-        <td>c.1024del (p.Tyr342ThrfsTer52)</td>
+        <td>12_114355723_114355723_G_A</td>
+        <td>c.1366C>T (p.Gln456Ter)</td>
         <td>9</td>
-        <td>frameshift</td>
-      </tr>
-      
-      <tr>
-        <td>1</td>
-        <td>12_114401921_114401921_C_G</td>
-        <td>c.148-1G>C (-)</td>
-        <td>-</td>
-        <td>splice acceptor</td>
-      </tr>
-      
-      <tr>
-        <td>1</td>
-        <td>12_114398602_114398602_T_G</td>
-        <td>c.481A>C (p.Thr161Pro)</td>
-        <td>5</td>
-        <td>missense</td>
-      </tr>
-      
-      <tr>
-        <td>1</td>
-        <td>12_114355755_114355756_TG_T</td>
-        <td>c.1333del (p.His445MetfsTer137)</td>
-        <td>9</td>
-        <td>frameshift</td>
-      </tr>
-      
-      <tr>
-        <td>1</td>
-        <td>12_114401873_114401874_TA_T</td>
-        <td>c.194del (p.Leu65GlnfsTer10)</td>
-        <td>3</td>
-        <td>frameshift</td>
-      </tr>
-      
-      <tr>
-        <td>1</td>
-        <td>12_114398626_114398627_CG_C</td>
-        <td>c.456del (p.Val153SerfsTer21)</td>
-        <td>5</td>
-        <td>frameshift</td>
+        <td>stop gained</td>
       </tr>
       
       <tr>
@@ -508,18 +508,34 @@
       
       <tr>
         <td>1</td>
-        <td>12_114399559_114399559_T_C</td>
-        <td>c.316A>G (p.Ile106Val)</td>
-        <td>4</td>
+        <td>12_114394817_114394817_G_C</td>
+        <td>c.587C>G (p.Ser196Ter)</td>
+        <td>6</td>
+        <td>stop gained</td>
+      </tr>
+      
+      <tr>
+        <td>1</td>
+        <td>12_114394743_114394746_TGTG_T</td>
+        <td>c.658_660del (p.His220del)</td>
+        <td>6</td>
+        <td>inframe deletion</td>
+      </tr>
+      
+      <tr>
+        <td>1</td>
+        <td>12_114403859_114403859_G_T</td>
+        <td>c.40C>A (p.Pro14Thr)</td>
+        <td>2</td>
         <td>missense</td>
       </tr>
       
       <tr>
         <td>1</td>
-        <td>12_114401846_114401846_C_G</td>
-        <td>c.222G>C (p.Met74Ile)</td>
-        <td>3</td>
-        <td>missense</td>
+        <td>12_114366348_114366349_CT_C</td>
+        <td>c.798del (p.Val267TrpfsTer127)</td>
+        <td>8</td>
+        <td>frameshift</td>
       </tr>
       
       <tr>
@@ -532,42 +548,26 @@
       
       <tr>
         <td>1</td>
-        <td>12_114355723_114355723_G_A</td>
-        <td>c.1366C>T (p.Gln456Ter)</td>
-        <td>9</td>
-        <td>stop gained</td>
-      </tr>
-      
-      <tr>
-        <td>1</td>
-        <td>12_114355784_114355785_CA_C</td>
-        <td>c.1304del (p.Leu435ArgfsTer147)</td>
-        <td>9</td>
-        <td>frameshift</td>
-      </tr>
-      
-      <tr>
-        <td>1</td>
-        <td>12_114394817_114394817_G_C</td>
-        <td>c.587C>G (p.Ser196Ter)</td>
-        <td>6</td>
-        <td>stop gained</td>
-      </tr>
-      
-      <tr>
-        <td>1</td>
-        <td>12_114399622_114399622_G_T</td>
-        <td>c.253C>A (p.Pro85Thr)</td>
-        <td>4</td>
+        <td>12_114398602_114398602_T_G</td>
+        <td>c.481A>C (p.Thr161Pro)</td>
+        <td>5</td>
         <td>missense</td>
       </tr>
       
       <tr>
         <td>1</td>
-        <td>12_114394743_114394746_TGTG_T</td>
-        <td>c.658_660del (p.His220del)</td>
-        <td>6</td>
-        <td>inframe deletion</td>
+        <td>12_114398626_114398627_CG_C</td>
+        <td>c.456del (p.Val153SerfsTer21)</td>
+        <td>5</td>
+        <td>frameshift</td>
+      </tr>
+      
+      <tr>
+        <td>1</td>
+        <td>12_114401873_114401874_TA_T</td>
+        <td>c.194del (p.Leu65GlnfsTer10)</td>
+        <td>3</td>
+        <td>frameshift</td>
       </tr>
       
     </tbody>

--- a/docs/report/tbx5_truncating_vs_missense.csv
+++ b/docs/report/tbx5_truncating_vs_missense.csv
@@ -1,8 +1,20 @@
 ,Missense,Truncating,Corrected p values,p values
-Ventricular septal defect [HP:0001629],31/60 (52%),29/29 (100%),9.550859422122477e-06,5.618152601248516e-07
+Ventricular septal defect [HP:0001629],31/60 (52%),29/29 (100%),1.685445780374555e-05,5.618152601248516e-07
+Patent foramen ovale [HP:0001655],4/40 (10%),0/62 (0%),0.26028179887989955,0.021505679979762674
+Triphalangeal thumb [HP:0001199],13/72 (18%),21/57 (37%),0.26028179887989955,0.026028179887989958
+Absent thumb [HP:0009777],12/71 (17%),19/57 (33%),0.2891465722255393,0.03855287629673857
+Complete atrioventricular canal defect [HP:0001674],5/37 (14%),3/63 (5%),0.8049542711586962,0.1419239358441169
+Perimembranous ventricular septal defect [HP:0011682],3/59 (5%),6/47 (13%),0.8049542711586962,0.18069478744841608
+Upper limb phocomelia [HP:0009813],8/85 (9%),2/65 (3%),0.8049542711586962,0.18782266327036246
+Short thumb [HP:0009778],11/41 (27%),22/56 (39%),1.0,0.2782218994250125
 Hypoplasia of the radius [HP:0002984],30/62 (48%),10/27 (37%),1.0,0.3614379675325876
+Muscular ventricular septal defect [HP:0011623],6/59 (10%),8/47 (17%),1.0,0.3894578351610228
+Amelia involving the upper limbs [HP:0009812],0/83 (0%),1/65 (2%),1.0,0.4391891891891892
 Atrial septal defect [HP:0001631],42/44 (95%),38/38 (100%),1.0,0.49653718759409815
 Secundum atrial septal defect [HP:0001684],14/35 (40%),13/40 (32%),1.0,0.6304400561799244
+Short 1st metacarpal [HP:0010034],0/30 (0%),1/35 (3%),1.0,1.0
+Common atrium [HP:0011565],0/83 (0%),0/66 (0%),1.0,1.0
+Unroofed coronary sinus [HP:0031297],0/85 (0%),0/66 (0%),1.0,1.0
 Abnormal thumb morphology [HP:0001172],30/30 (100%),56/56 (100%),1.0,1.0
 Abnormal finger morphology [HP:0001167],36/36 (100%),56/56 (100%),1.0,1.0
 Abnormal digit morphology [HP:0011297],38/38 (100%),59/59 (100%),1.0,1.0
@@ -16,3 +28,4 @@ Aplasia/hypoplasia involving bones of the extremities [HP:0045060],55/55 (100%),
 Aplasia/hypoplasia involving the skeleton [HP:0009115],56/56 (100%),45/45 (100%),1.0,1.0
 Abnormal cardiac septum morphology [HP:0001671],62/62 (100%),50/50 (100%),1.0,1.0
 Abnormal appendicular skeleton morphology [HP:0011844],64/64 (100%),60/60 (100%),1.0,1.0
+Absent radius [HP:0003974],7/32 (22%),7/35 (20%),1.0,1.0

--- a/docs/report/tbx5_truncating_vs_missense.mtc_report.html
+++ b/docs/report/tbx5_truncating_vs_missense.mtc_report.html
@@ -134,7 +134,7 @@
 <div class="cards">
   <div class="card">
     <ul>
-      <li>Phenotype MTC filter: <em>HPO MTC filter</em></li>
+      <li>Phenotype MTC filter: <em>Independent filtering HPO filter</em></li>
       <li>Multiple testing correction: <em>fdr_bh</em></li>
     </ul>
   </div>
@@ -148,9 +148,9 @@
         </tr>
         
         <tr>
-          <td>HMF01</td>
-          <td>Skipping term with maximum frequency that was less than threshold 0.4</td>
-          <td>19</td>
+          <td>HMF03</td>
+          <td>Skipping term because of a child term with the same individual counts</td>
+          <td>1</td>
         </tr>
         
         <tr>
@@ -161,13 +161,13 @@
         
         <tr>
           <td>HMF09</td>
-          <td>Skipping term with maximum annotation frequency that was less than threshold 0.4</td>
-          <td>285</td>
+          <td>Skipping term that was annotated to less than 40% of the cohort members</td>
+          <td>290</td>
         </tr>
         
       </tbody>
       <caption>
-        Performed statistical tests for 17 out of the total of 369 HPO terms.
+        Performed statistical tests for 30 out of the total of 369 HPO terms.
       </caption>
     </table>
   </div>

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -338,15 +338,15 @@ Now we can perform the testing and evaluate the results.
 ...     pheno_clfs=pheno_clfs,
 ... )
 >>> result.total_tests
-17
+30
 
-We only tested 17 HPO terms. This is despite the individuals being collectively annotated with
+We only tested 30 HPO terms. This is despite the individuals being collectively annotated with
 369 direct and indirect HPO terms
 
 >>> len(result.phenotypes)
 369
 
-We can show the reasoning behind *not* testing 352 (`369 - 17`) HPO terms
+We can show the reasoning behind *not* testing 339 (`369 - 30`) HPO terms
 by exploring the phenotype MTC filtering report:
 
 >>> from gpsea.view import MtcStatsViewer

--- a/docs/user-guide/analyses/phenotype-classes.rst
+++ b/docs/user-guide/analyses/phenotype-classes.rst
@@ -295,12 +295,12 @@ We can now test associations between the genotype classes and the HPO terms:
 >>> len(result.phenotypes)
 369
 >>> result.total_tests
-24
+32
 
 
 We tested the ``cohort`` for association between the genotype classes (``gt_clf``)
 and HPO terms (``pheno_clfs``).
-Thanks to phenotype MT filter, we only tested 24 out of 369 terms.
+Thanks to phenotype MT filter, we only tested 32 out of 369 terms.
 The MT filter report shows the filtering details:
 
 >>> from gpsea.view import MtcStatsViewer

--- a/docs/user-guide/analyses/report/tbx5_frameshift.csv
+++ b/docs/user-guide/analyses/report/tbx5_frameshift.csv
@@ -1,14 +1,21 @@
 ,Frameshift,Other,Corrected p values,p values
-Ventricular septal defect [HP:0001629],19/19 (100%),42/71 (59%),0.005806240832840839,0.00024192670136836828
-Absent thumb [HP:0009777],14/31 (45%),18/100 (18%),0.04456405819223913,0.0037136715160199273
-Secundum atrial septal defect [HP:0001684],4/22 (18%),23/55 (42%),0.4065940176561687,0.06544319142266644
-Triphalangeal thumb [HP:0001199],13/32 (41%),23/99 (23%),0.4065940176561687,0.06932119159387057
-Muscular ventricular septal defect [HP:0011623],6/25 (24%),8/84 (10%),0.4065940176561687,0.08470708701170182
+Ventricular septal defect [HP:0001629],19/19 (100%),42/71 (59%),0.007741654443787785,0.00024192670136836828
+Absent thumb [HP:0009777],14/31 (45%),18/100 (18%),0.05941874425631884,0.0037136715160199273
+Secundum atrial septal defect [HP:0001684],4/22 (18%),23/55 (42%),0.5421253568748916,0.06544319142266644
+Triphalangeal thumb [HP:0001199],13/32 (41%),23/99 (23%),0.5421253568748916,0.06932119159387057
+Muscular ventricular septal defect [HP:0011623],6/25 (24%),8/84 (10%),0.5421253568748916,0.08470708701170182
+Amelia involving the upper limbs [HP:0009812],1/37 (3%),0/114 (0%),1.0,0.24503311258278143
+Patent foramen ovale [HP:0001655],0/36 (0%),4/69 (6%),1.0,0.29623386322415446
+Perimembranous ventricular septal defect [HP:0011682],3/25 (12%),6/84 (7%),1.0,0.4256518230307461
 Short thumb [HP:0009778],8/30 (27%),25/69 (36%),1.0,0.4870099714553749
 Absent radius [HP:0003974],6/25 (24%),9/43 (21%),1.0,0.7703831604944444
+Short 1st metacarpal [HP:0010034],0/22 (0%),1/45 (2%),1.0,1.0
+Common atrium [HP:0011565],0/38 (0%),1/115 (1%),1.0,1.0
+Unroofed coronary sinus [HP:0031297],0/38 (0%),1/117 (1%),1.0,1.0
 Abnormal long bone morphology [HP:0011314],13/13 (100%),50/50 (100%),1.0,1.0
 Aplasia/Hypoplasia of fingers [HP:0006265],19/19 (100%),44/44 (100%),1.0,1.0
 Aplasia/hypoplasia involving bones of the hand [HP:0005927],19/19 (100%),44/44 (100%),1.0,1.0
+Upper limb phocomelia [HP:0009813],2/37 (5%),8/116 (7%),1.0,1.0
 Atrial septal defect [HP:0001631],20/20 (100%),63/65 (97%),1.0,1.0
 Abnormal atrial septum morphology [HP:0011994],20/20 (100%),64/64 (100%),1.0,1.0
 Abnormal cardiac atrium morphology [HP:0005120],20/20 (100%),64/64 (100%),1.0,1.0
@@ -18,6 +25,7 @@ Aplasia/hypoplasia involving bones of the upper limbs [HP:0006496],22/22 (100%),
 Aplasia/hypoplasia involving bones of the extremities [HP:0045060],22/22 (100%),78/78 (100%),1.0,1.0
 Aplasia/hypoplasia involving the skeleton [HP:0009115],23/23 (100%),80/80 (100%),1.0,1.0
 Abnormal cardiac septum morphology [HP:0001671],28/28 (100%),89/89 (100%),1.0,1.0
+Complete atrioventricular canal defect [HP:0001674],3/36 (8%),6/67 (9%),1.0,1.0
 Abnormal thumb morphology [HP:0001172],31/31 (100%),58/58 (100%),1.0,1.0
 Abnormal finger morphology [HP:0001167],31/31 (100%),64/64 (100%),1.0,1.0
 Abnormal digit morphology [HP:0011297],33/33 (100%),67/67 (100%),1.0,1.0

--- a/docs/user-guide/analyses/report/tbx5_frameshift.mtc_report.html
+++ b/docs/user-guide/analyses/report/tbx5_frameshift.mtc_report.html
@@ -134,7 +134,7 @@
 <div class="cards">
   <div class="card">
     <ul>
-      <li>Phenotype MTC filter: <em>HPO MTC filter</em></li>
+      <li>Phenotype MTC filter: <em>Independent filtering HPO filter</em></li>
       <li>Multiple testing correction: <em>fdr_bh</em></li>
     </ul>
   </div>
@@ -148,9 +148,9 @@
         </tr>
         
         <tr>
-          <td>HMF01</td>
-          <td>Skipping term with maximum frequency that was less than threshold 0.2</td>
-          <td>10</td>
+          <td>HMF03</td>
+          <td>Skipping term because of a child term with the same individual counts</td>
+          <td>1</td>
         </tr>
         
         <tr>
@@ -161,13 +161,13 @@
         
         <tr>
           <td>HMF09</td>
-          <td>Skipping term with maximum annotation frequency that was less than threshold 0.4</td>
-          <td>287</td>
+          <td>Skipping term that was annotated to less than 40% of the cohort members</td>
+          <td>288</td>
         </tr>
         
       </tbody>
       <caption>
-        Performed statistical tests for 24 out of the total of 369 HPO terms.
+        Performed statistical tests for 32 out of the total of 369 HPO terms.
       </caption>
     </table>
   </div>

--- a/src/gpsea/analysis/mtc_filter/_impl.py
+++ b/src/gpsea/analysis/mtc_filter/_impl.py
@@ -339,7 +339,7 @@ class IfHpoFilter(PhenotypeMtcFilter[hpotk.TermId]):
 
         return IfHpoFilter(
             hpo=hpo,
-            term_frequency_threshold=term_frequency_threshold,
+            # term_frequency_threshold=term_frequency_threshold,
             annotation_frequency_threshold=annotation_frequency_threshold,
             general_hpo_terms=general_hpo_term_set,
         )
@@ -347,34 +347,35 @@ class IfHpoFilter(PhenotypeMtcFilter[hpotk.TermId]):
     def __init__(
         self,
         hpo: hpotk.MinimalOntology,
-        term_frequency_threshold: float,
+        # term_frequency_threshold: float,
         annotation_frequency_threshold: float,
         general_hpo_terms: typing.Iterable[hpotk.TermId],
     ):
         self._hpo = hpo
-        assert (
-            isinstance(term_frequency_threshold, (int, float))
-            and 0.0 < term_frequency_threshold <= 1.0
-        ), "The term_frequency_threshold must be in the range (0, 1]"
-        self._hpo_term_frequency_filter = term_frequency_threshold
+        # assert (
+        #     isinstance(term_frequency_threshold, (int, float))
+        #     and 0.0 < term_frequency_threshold <= 1.0
+        # ), "The term_frequency_threshold must be in the range (0, 1]"
+        # self._hpo_term_frequency_filter = term_frequency_threshold
         assert (
             isinstance(annotation_frequency_threshold, (int, float))
             and 0.0 < annotation_frequency_threshold <= 1.0
         ), "The annotation_frequency_threshold must be in the range (0, 1]"
         self._hpo_annotation_frequency_threshold = annotation_frequency_threshold
+        # self._hpo_annotation_frequency_threshold_perc = self._hpo_annotation_frequency_threshold * 100
 
         self._general_hpo_terms = set(general_hpo_terms)
 
-        self._below_frequency_threshold = PhenotypeMtcResult.fail(
-            code="HMF01",
-            reason="Skipping term with maximum frequency that was"
-            f" less than threshold {self._hpo_term_frequency_filter}",
-        )
-
+        # self._below_frequency_threshold = PhenotypeMtcResult.fail(
+        #     code="HMF01",
+        #     reason="Skipping term with maximum frequency that was"
+        #     f" less than threshold {self._hpo_term_frequency_filter}",
+        # )
+        
         self._below_annotation_frequency_threshold = PhenotypeMtcResult.fail(
             code="HMF09",
-            reason="Skipping term with maximum annotation frequency that was"
-            f" less than threshold {self._hpo_annotation_frequency_threshold}",
+            reason="Skipping term that was annotated to less than "
+            f"{self._hpo_annotation_frequency_threshold:.0%} of the cohort members",
         )
 
         # Do not perform a test if the counts in the genotype categories do not even have nominal statistical power
@@ -435,16 +436,16 @@ class IfHpoFilter(PhenotypeMtcFilter[hpotk.TermId]):
                 results[idx] = IfHpoFilter.SKIPPING_NON_PHENOTYPE_TERM
                 continue
 
-            ph_clf = pheno_clfs[idx]
+            # ph_clf = pheno_clfs[idx]
             contingency_matrix = counts[idx]
 
-            max_freq = IfHpoFilter.get_maximum_group_observed_HPO_frequency(
-                contingency_matrix,
-                ph_clf=ph_clf,
-            )
-            if max_freq < self._hpo_term_frequency_filter:
-                results[idx] = self._below_frequency_threshold
-                continue
+            # max_freq = IfHpoFilter.get_maximum_group_observed_HPO_frequency(
+            #     contingency_matrix,
+            #     ph_clf=ph_clf,
+            # )
+            # if max_freq < self._hpo_term_frequency_filter:
+            #     results[idx] = self._below_frequency_threshold
+            #     continue
 
             total_count = contingency_matrix.sum().sum()
             if total_count < annotation_count_thr:
@@ -517,7 +518,7 @@ class IfHpoFilter(PhenotypeMtcFilter[hpotk.TermId]):
     def possible_results(self) -> typing.Collection[PhenotypeMtcResult]:
         return (
             PhenotypeMtcFilter.OK,
-            self._below_frequency_threshold,  # HMF01
+            # self._below_frequency_threshold,  # HMF01
             # HMF02 - gone
             IfHpoFilter.SAME_COUNT_AS_THE_ONLY_CHILD,  # HMF03
             # HMF04 - gone

--- a/tests/analysis/test_mtc_filter.py
+++ b/tests/analysis/test_mtc_filter.py
@@ -217,19 +217,19 @@ class TestIfHpoFilter:
         )
         assert max_f == pytest.approx(0.5714, abs=EPSILON)
 
-    def test_mtc_filter_term_frequency_threshold_raises(
-        self,
-        hpo: hpotk.MinimalOntology,
-    ):
-        with pytest.raises(AssertionError) as e:
-            IfHpoFilter.default_filter(
-                hpo=hpo,
-                term_frequency_threshold=1.1,
-                annotation_frequency_threshold=0.1,
-            )
-        assert e.value.args == (
-            "The term_frequency_threshold must be in the range (0, 1]",
-        )
+    # def test_mtc_filter_term_frequency_threshold_raises(
+    #     self,
+    #     hpo: hpotk.MinimalOntology,
+    # ):
+    #     with pytest.raises(AssertionError) as e:
+    #         IfHpoFilter.default_filter(
+    #             hpo=hpo,
+    #             term_frequency_threshold=1.1,
+    #             annotation_frequency_threshold=0.1,
+    #         )
+    #     assert e.value.args == (
+    #         "The term_frequency_threshold must be in the range (0, 1]",
+    #     )
 
     def test_mtc_filter_annotation_frequency_threshold_raises(
         self,


### PR DESCRIPTION
Disable `HMF01` - filtering by minimal proportion of observed HPO in a genotype class.