### PR TITLE
Check for protein annotations before plotting a diagram

### DIFF
--- a/src/gpsea/view/_protein_visualizable.py
+++ b/src/gpsea/view/_protein_visualizable.py
@@ -155,7 +155,8 @@ class ProteinVisualizable:
         return self._variant_locations_counted_absolute
 
     @property
-    def marker_counts(self):
+    def marker_counts(self) -> np.ndarray:
+        # `self._marker_counts` should be a 1D array with non-negative ints (counts).
         return self._marker_counts
 
     @property

--- a/tests/view/test_protein_visualizer.py
+++ b/tests/view/test_protein_visualizer.py
@@ -29,3 +29,21 @@ class TestProteinVisualizer:
 
         fig.savefig("protein.png")
 
+    def test_drawing_with_empty_cohort(
+        self,
+        visualizer: BaseProteinVisualizer,
+        suox_protein_metadata: ProteinMetadata,
+    ):
+        empty = Cohort(members=(), excluded_member_count=0)
+
+        _, ax = plt.subplots(figsize=(20, 20))
+        with pytest.raises(ValueError) as e:
+            visualizer.draw_protein(
+                cohort=empty,
+                protein_metadata=suox_protein_metadata,
+                ax=ax,
+            )
+
+        assert e.value.args == (
+            'No variants annotated with respect to "NP_001027558.1" were found',
+        )


### PR DESCRIPTION
Raise an exception if there is no variant annotated with respect to the target protein, when plotting a protein diagram.

Fixes #415