### PR TITLE
Remove HMF01, link out from MTC filter

### DIFF
--- a/docs/report/tbx5_truncating_vs_missense.mtc_report.html
+++ b/docs/report/tbx5_truncating_vs_missense.mtc_report.html
@@ -142,26 +142,28 @@
     <table>
       <tbody>
         <tr>
-          <th>Code</th>
           <th>Reason</th>
           <th>Count</th>
         </tr>
         
         <tr>
-          <td>HMF03</td>
-          <td>Skipping term because of a child term with the same individual counts</td>
+          
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf03">Skipping term because of a child term with the same individual counts</a></td>
+          
           <td>1</td>
         </tr>
         
         <tr>
-          <td>HMF08</td>
-          <td>Skipping general term</td>
+          
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf08">Skipping general term</a></td>
+          
           <td>48</td>
         </tr>
         
         <tr>
-          <td>HMF09</td>
-          <td>Skipping term that was annotated to less than 40% of the cohort members</td>
+          
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf09">Skipping term that was annotated to less than 40% of the cohort members</a></td>
+          
           <td>290</td>
         </tr>
         

--- a/docs/report/tbx5_truncating_vs_missense.mtc_report.html
+++ b/docs/report/tbx5_truncating_vs_missense.mtc_report.html
@@ -148,21 +148,21 @@
         
         <tr>
           
-            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf03">Skipping term because of a child term with the same individual counts</a></td>
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html/#skip-terms-if-all-counts-are-identical-to-counts-for-a-child-term">Skipping term because of a child term with the same individual counts</a></td>
           
           <td>1</td>
         </tr>
         
         <tr>
           
-            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf08">Skipping general term</a></td>
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html/#skipping-general-level-terms">Skipping general term</a></td>
           
           <td>48</td>
         </tr>
         
         <tr>
           
-            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf09">Skipping term that was annotated to less than 40% of the cohort members</a></td>
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html/#skipping-terms-that-are-rare-on-the-cohort-level">Skipping term that was annotated to less than 40% of the cohort members</a></td>
           
           <td>290</td>
         </tr>

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -371,7 +371,7 @@ and these are the tested HPO terms ordered by the p value corrected with the Ben
 
 .. csv-table:: *TBX5* truncating vs. missense
    :file: report/tbx5_truncating_vs_missense.csv
-   :header-rows: 2
+   :header-rows: 1
 
 .. doctest:: tutorial
   :hide:
@@ -397,4 +397,4 @@ and we found an association between truncating *TBX5* variants
 and `Ventricular septal defect <https://hpo.jax.org/browse/term/HP:0001629>`_.
 
 This is just one of many analysis types that are possible with GPSEA.
-Please refer to the User guide (next section) to learn more.
+Please refer to the user guide (next section) to learn more.

--- a/docs/user-guide/analyses/mtc.rst
+++ b/docs/user-guide/analyses/mtc.rst
@@ -179,7 +179,7 @@ Independent filtering for HPO
 Independent filtering for HPO involves making several domain judgments
 and taking advantage of the HPO structure
 in order to reduce the number of HPO terms for testing.
-The filter's logic is made up of 8 individual heuristics 
+The filter's logic is made up of 6 individual heuristics 
 to skip testing the terms that are unlikely to yield significant or interesting results (see below).
 
 Some of the heuristics need to access HPO hierarchy,
@@ -197,7 +197,7 @@ using the static constructor
 >>> hpo_mtc = IfHpoFilter.default_filter(hpo=hpo)
 
 
-The constructor takes HPO and two thresholds (optional).
+The constructor takes HPO and one threshold (optional).
 See the API documentation and the explanations below for more details.
 
 
@@ -205,8 +205,6 @@ See the API documentation and the explanations below for more details.
   :depth: 1
   :local:
 
-
-.. _hmf03:
 
 Skip terms if all counts are identical to counts for a child term
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -225,14 +223,11 @@ and the result of a test, such as the Fisher Exact test, would be exactly the sa
 for *Polar cataract* as for *Posterior polar cataract*.
 
 
-.. _hmf05:
-
 Skip term if one of the genotype groups has neither observed nor excluded observations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Skip terms if there are no HPO observations in a group.
 
-.. _hmf06:
 
 Skip term if underpowered for 2x2 or 2x3 analysis
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -244,8 +239,6 @@ is less than 6, then there is a lack even of the nominal statistical power
 and the counts can never be significant.
 
 
-.. _hmf07:
-
 Skipping terms that are not descendents of *Phenotypic abnormality*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -255,8 +248,6 @@ We do not think it makes much sense to test for enrichment of these terms,
 so, all terms that are not descendants of
 `Phenotypic abnormality <https://hpo.jax.org/browse/term/HP:0000118>`_ are filtered out.
 
-
-.. _hmf08:
 
 Skipping "general" level terms
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -275,8 +266,6 @@ it will lead to at least one of the descendents of
 
 See :ref:`general-hpo-terms` section for details.
 
-
-.. _hmf09:
 
 Skipping terms that are rare on the cohort level 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/user-guide/analyses/mtc.rst
+++ b/docs/user-guide/analyses/mtc.rst
@@ -206,23 +206,10 @@ See the API documentation and the explanations below for more details.
   :local:
 
 
-`HMF01` - Skip terms that occur very rarely
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _hmf03:
 
-The ``term_frequency_threshold`` determines the mininum proportion of individuals
-with direct or indirect annotation by the HPO term to test.
-We check each of the genotype groups (e.g., MISSENSE vs. not-MISSENSE),
-and we only retain a term for testing if the proportion of individuals
-in at least one genotype group is greater than
-or equal to ``term_frequency_threshold``.
-This is because of our assumption that even if there is statistical significance,
-if a term is only seen in (for example) 7% of individuals
-in the MISSENSE group and 2% in the not-MISSENSE group,
-the term is unlikely to be of great interest because it is rare.
-
-
-`HMF03` - Skip terms if all counts are identical to counts for a child term
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Skip terms if all counts are identical to counts for a child term
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Let's say a term such as    
 `Posterior polar cataract (HP:0001115) <https://hpo.jax.org/browse/term/HP:0001115>`_
@@ -238,14 +225,17 @@ and the result of a test, such as the Fisher Exact test, would be exactly the sa
 for *Polar cataract* as for *Posterior polar cataract*.
 
 
-`HMF05` - Skip term if one of the genotype groups has neither observed nor excluded observations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _hmf05:
+
+Skip term if one of the genotype groups has neither observed nor excluded observations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Skip terms if there are no HPO observations in a group.
 
+.. _hmf06:
 
-`HMF06` - Skip term if underpowered for 2x2 or 2x3 analysis
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Skip term if underpowered for 2x2 or 2x3 analysis
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If the individuals are binned into 2 phenotype groups and 2 genotype groups (2x2)
 and the total count of patients in all genotype-phenotype groups is less than 7,
@@ -254,8 +244,10 @@ is less than 6, then there is a lack even of the nominal statistical power
 and the counts can never be significant.
 
 
-`HMF07` - Skipping terms that are not descendents of *Phenotypic abnormality*
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _hmf07:
+
+Skipping terms that are not descendents of *Phenotypic abnormality*
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The HPO has a number of other branches that describe modes of inheritance,
 past medical history, and clinical modifiers.
@@ -264,8 +256,10 @@ so, all terms that are not descendants of
 `Phenotypic abnormality <https://hpo.jax.org/browse/term/HP:0000118>`_ are filtered out.
 
 
-`HMF08` - Skipping "general" level terms
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _hmf08:
+
+Skipping "general" level terms
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All the direct children of the root phenotype term
 `Phenotypic abnormality (HP:0000118) <https://hpo.jax.org/browse/term/HP:0000118>`_
@@ -282,8 +276,10 @@ it will lead to at least one of the descendents of
 See :ref:`general-hpo-terms` section for details.
 
 
-`HMF09` - Skipping terms that are rare on the cohort level 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _hmf09:
+
+Skipping terms that are rare on the cohort level 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We skip terms that occur in less than a certain percentage of cohort members.
 The purpose of this threshold is to omit terms for which we simply

--- a/docs/user-guide/analyses/phenotype-classes.rst
+++ b/docs/user-guide/analyses/phenotype-classes.rst
@@ -243,7 +243,7 @@ we can configure the analysis manually.
 First, we choose a phenotype MT filter (e.g. :class:`~gpsea.analysis.mtc_filter.IfHpoFilter`):
 
 >>> from gpsea.analysis.mtc_filter import IfHpoFilter
->>> mtc_filter = IfHpoFilter.default_filter(hpo, term_frequency_threshold=.2)
+>>> mtc_filter = IfHpoFilter.default_filter(hpo)
 
 .. note::
 

--- a/docs/user-guide/analyses/phenotype-classes.rst
+++ b/docs/user-guide/analyses/phenotype-classes.rst
@@ -331,7 +331,7 @@ one HPO term per row. The rows are ordered by the corrected p value and nominal 
 
 .. csv-table:: *TBX5* frameshift vs rest
    :file: report/tbx5_frameshift.csv
-   :header-rows: 2
+   :header-rows: 1
 
 .. doctest:: phenotype-classes
    :hide:
@@ -346,5 +346,5 @@ was observed in 42/71 (59%) patients with no frameshift allele (`Other`)
 but it was observed in 19/19 (100%) patients with a frameshift allele (`Frameshift`).
 Fisher exact test computed a p value of `~0.000242`
 and the p value corrected by Benjamini-Hochberg procedure
-is `~0.005806`.
+is `~0.00774`.
 

--- a/docs/user-guide/analyses/report/tbx5_frameshift.mtc_report.html
+++ b/docs/user-guide/analyses/report/tbx5_frameshift.mtc_report.html
@@ -148,21 +148,21 @@
         
         <tr>
           
-            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf03">Skipping term because of a child term with the same individual counts</a></td>
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html/#skip-terms-if-all-counts-are-identical-to-counts-for-a-child-term">Skipping term because of a child term with the same individual counts</a></td>
           
           <td>1</td>
         </tr>
         
         <tr>
           
-            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf08">Skipping general term</a></td>
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html/#skipping-general-level-terms">Skipping general term</a></td>
           
           <td>48</td>
         </tr>
         
         <tr>
           
-            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf09">Skipping term that was annotated to less than 40% of the cohort members</a></td>
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html/#skipping-terms-that-are-rare-on-the-cohort-level">Skipping term that was annotated to less than 40% of the cohort members</a></td>
           
           <td>288</td>
         </tr>

--- a/docs/user-guide/analyses/report/tbx5_frameshift.mtc_report.html
+++ b/docs/user-guide/analyses/report/tbx5_frameshift.mtc_report.html
@@ -142,26 +142,28 @@
     <table>
       <tbody>
         <tr>
-          <th>Code</th>
           <th>Reason</th>
           <th>Count</th>
         </tr>
         
         <tr>
-          <td>HMF03</td>
-          <td>Skipping term because of a child term with the same individual counts</td>
+          
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf03">Skipping term because of a child term with the same individual counts</a></td>
+          
           <td>1</td>
         </tr>
         
         <tr>
-          <td>HMF08</td>
-          <td>Skipping general term</td>
+          
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf08">Skipping general term</a></td>
+          
           <td>48</td>
         </tr>
         
         <tr>
-          <td>HMF09</td>
-          <td>Skipping term that was annotated to less than 40% of the cohort members</td>
+          
+            <td><a href="https://monarch-initiative.github.io/gpsea/stable/user-guide/analyses/mtc.html#hmf09">Skipping term that was annotated to less than 40% of the cohort members</a></td>
+          
           <td>288</td>
         </tr>
         

--- a/src/gpsea/__init__.py
+++ b/src/gpsea/__init__.py
@@ -8,3 +8,5 @@ _overwrite = False
 """
 A private "hack" flag for regenerating documentation output (HTML fragments, figures).
 """
+
+_BASE_URL = "https://monarch-initiative.github.io/gpsea/stable"

--- a/src/gpsea/analysis/mtc_filter/_impl.py
+++ b/src/gpsea/analysis/mtc_filter/_impl.py
@@ -280,19 +280,35 @@ class IfHpoFilter(PhenotypeMtcFilter[hpotk.TermId]):
     SAME_COUNT_AS_THE_ONLY_CHILD = PhenotypeMtcResult.fail(
         "HMF03",
         "Skipping term because of a child term with the same individual counts",
-        doclink=os.path.join(_BASE_URL, __DOC_SECTION, "#hmf03"),
+        doclink=os.path.join(
+            _BASE_URL,
+            __DOC_SECTION,
+            "#skip-terms-if-all-counts-are-identical-to-counts-for-a-child-term",
+        ),
     )
     SKIPPING_SINCE_ONE_GENOTYPE_HAD_ZERO_OBSERVATIONS = PhenotypeMtcResult.fail(
         "HMF05", "Skipping term because one genotype had zero observations",
-        doclink=os.path.join(_BASE_URL, __DOC_SECTION, "#hmf05"),
+        doclink=os.path.join(
+            _BASE_URL,
+            __DOC_SECTION,
+            "#skip-term-if-one-of-the-genotype-groups-has-neither-observed-nor-excluded-observations",
+        ),
     )
     SKIPPING_NON_PHENOTYPE_TERM = PhenotypeMtcResult.fail(
         "HMF07", "Skipping non phenotype term",
-        doclink=os.path.join(_BASE_URL, __DOC_SECTION, "#hmf07"),
+        doclink=os.path.join(
+            _BASE_URL,
+            __DOC_SECTION,
+            "#skipping-terms-that-are-not-descendents-of-phenotypic-abnormality",
+        ),
     )
     SKIPPING_GENERAL_TERM = PhenotypeMtcResult.fail(
         "HMF08", "Skipping general term",
-        doclink=os.path.join(_BASE_URL, __DOC_SECTION, "#hmf08"),
+        doclink=os.path.join(
+            _BASE_URL,
+            __DOC_SECTION,
+            "#skipping-general-level-terms",
+        ),
     )
 
     @staticmethod
@@ -378,7 +394,11 @@ class IfHpoFilter(PhenotypeMtcFilter[hpotk.TermId]):
             code="HMF09",
             reason="Skipping term that was annotated to less than "
             f"{self._hpo_annotation_frequency_threshold:.0%} of the cohort members",
-            doclink=os.path.join(_BASE_URL, IfHpoFilter.__DOC_SECTION, "#hmf09"),
+            doclink=os.path.join(
+                _BASE_URL,
+                IfHpoFilter.__DOC_SECTION,
+                "#skipping-terms-that-are-rare-on-the-cohort-level",
+            ),
         )
 
         # Do not perform a test if the counts in the genotype categories do not even have nominal statistical power
@@ -399,14 +419,22 @@ class IfHpoFilter(PhenotypeMtcFilter[hpotk.TermId]):
             code="HMF06",
             reason=f"Skipping term with less than {self._min_observations_for_2_by_2} observations"
             " (not powered for 2x2)",
-            doclink=os.path.join(_BASE_URL, IfHpoFilter.__DOC_SECTION, "#hmf06"),
+            doclink=os.path.join(
+                _BASE_URL,
+                IfHpoFilter.__DOC_SECTION,
+                "#skip-term-if-underpowered-for-2x2-or-2x3-analysis",
+            ),
         )
         self._min_observations_for_2_by_3 = 6
         self._not_powered_for_2_by_3 = PhenotypeMtcResult.fail(
             code="HMF06",
             reason=f"Skipping term with less than {self._min_observations_for_2_by_3} observations"
             " (not powered for 2x3)",
-            doclink=os.path.join(_BASE_URL, IfHpoFilter.__DOC_SECTION, "#hmf06"),
+            doclink=os.path.join(
+                _BASE_URL,
+                IfHpoFilter.__DOC_SECTION,
+                "#skip-term-if-underpowered-for-2x2-or-2x3-analysis",
+            ),
         )
 
     def filter(

--- a/src/gpsea/view/_viewers.py
+++ b/src/gpsea/view/_viewers.py
@@ -664,6 +664,7 @@ class MtcStatsViewer(BaseViewer):
                 {
                     "code": mtc_issue.code,
                     "reason": mtc_issue.reason,
+                    "doclink": mtc_issue.doclink,
                     "count": count,
                 }
             )

--- a/src/gpsea/view/templates/stats.html
+++ b/src/gpsea/view/templates/stats.html
@@ -12,14 +12,16 @@
     <table>
       <tbody>
         <tr>
-          <th>Code</th>
           <th>Reason</th>
           <th>Count</th>
         </tr>
-        {% for skipped  in issue_to_count %}
+        {% for skipped in issue_to_count %}
         <tr>
-          <td>{{ skipped.code }}</td>
-          <td>{{ skipped.reason }}</td>
+          {% if skipped.doclink is none %}
+            <td>{{ skipped.reason }}</td>
+          {% else %}
+            <td><a href="{{ skipped.doclink }}">{{ skipped.reason }}</a></td>
+          {% endif %}
           <td>{{ skipped.count }}</td>
         </tr>
         {% endfor %}

--- a/tests/analysis/pcats/test_hpo_term_analysis.py
+++ b/tests/analysis/pcats/test_hpo_term_analysis.py
@@ -24,7 +24,6 @@ class TestHpoTermAnalysis:
     ) -> PhenotypeMtcFilter:
         return IfHpoFilter.default_filter(
             hpo=hpo,
-            term_frequency_threshold=0.2,
             annotation_frequency_threshold=0.25,
         )
 

--- a/tests/analysis/test_mtc_filter.py
+++ b/tests/analysis/test_mtc_filter.py
@@ -33,7 +33,6 @@ class TestIfHpoFilter:
     ) -> IfHpoFilter:
         return IfHpoFilter.default_filter(
             hpo=hpo,
-            term_frequency_threshold=0.2,
             annotation_frequency_threshold=0.1,
         )
 
@@ -95,32 +94,6 @@ class TestIfHpoFilter:
 
         assert actual == expected
 
-    @pytest.mark.parametrize(
-        "counts, expected",
-        [
-            ((1, 2, 99, 198), 0.01),
-            ((1, 3, 99, 197), 0.015),
-            ((0, 0, 100, 200), 0.0),
-            ((0, 0, 0, 200), 0.0),
-            ((0, 0, 0, 0), 0.0),
-        ],
-    )
-    def test_get_maximum_group_observed_HPO_frequency(
-        self,
-        counts: typing.Tuple[int],
-        expected: float,
-        gt_clf: GenotypeClassifier,
-        ph_predicate: PhenotypeClassifier[hpotk.TermId],
-    ):
-        counts_df = TestIfHpoFilter.prepare_counts_df(counts, gt_clf, ph_predicate)
-
-        actual = IfHpoFilter.get_maximum_group_observed_HPO_frequency(
-            counts_frame=counts_df,
-            ph_clf=ph_predicate,
-        )
-
-        assert actual == pytest.approx(expected)
-
     def test_filter_terms_to_test(
         self,
         mtc_filter: IfHpoFilter,
@@ -151,86 +124,6 @@ class TestIfHpoFilter:
             None,
         ]
 
-    def test_min_observed_HPO_threshold(
-        self,
-        suox_pheno_clfs: typing.Sequence[PhenotypeClassifier[hpotk.TermId]],
-        patient_counts: typing.Sequence[pd.DataFrame],
-    ):
-        """
-        In our heuristic filter, we only test terms that have at least a threshold
-        frequency in at least one of the groups. We use the `patient_counts` - a sequence of DataFrames
-        with 2x2 contingenicy tables of counts. For instance, each column will have one row for
-        PatientCategories.YES and one for PatientCategories.NO, indicating counts of measured observed/excluded
-        HPO phenotypes. Each column is a certain genotype, e.g., MISSENSE or NON-MISSENSE. We want the
-        function to return the maximum frequency. In each column, the frequency is calculate by
-        PatientCategories.YES / (PatientCategories.YES+PatientCategories.NO). This function tests that this works
-        for all of the HPO terms in the dictionary.
-        """
-        EPSILON = 0.001
-        curie2idx = {p.phenotype.value: i for i, p in enumerate(suox_pheno_clfs)}
-        # Ectopia lentis HP:0001083  (1 2  3 1), freqs are 1/4=0.25 and 3/4=0.75
-        idx = curie2idx["HP:0001083"]
-        ectopia = patient_counts[idx]
-        ectopia_predicate = suox_pheno_clfs[idx]
-        max_f = IfHpoFilter.get_maximum_group_observed_HPO_frequency(
-            ectopia,
-            ph_clf=ectopia_predicate,
-        )
-        assert max_f == pytest.approx(0.75, abs=EPSILON)
-
-        # Seizure HP:0001250 (11 5 0 1), freqs are 11/11=1.0 and 5/6=0.8333333
-        idx = curie2idx["HP:0001250"]
-        seizure = patient_counts[idx]
-        seizure_predicate = suox_pheno_clfs[idx]
-        max_f = IfHpoFilter.get_maximum_group_observed_HPO_frequency(
-            seizure, ph_clf=seizure_predicate
-        )
-        assert max_f == pytest.approx(1.0, abs=EPSILON)
-
-        # Sulfocysteinuria HP:0032350 (2 3 0 0), freqs are both 1
-        idx = curie2idx["HP:0032350"]
-        sulfocysteinuria = patient_counts[idx]
-        sulfocysteinuria_predicate = suox_pheno_clfs[idx]
-        max_f = IfHpoFilter.get_maximum_group_observed_HPO_frequency(
-            sulfocysteinuria,
-            ph_clf=sulfocysteinuria_predicate,
-        )
-        assert max_f == pytest.approx(1.0, abs=EPSILON)
-
-        # Neurodevelopmental delay HP:0012758 (4 0 4 5), freqs are 4/8 = 0.5 and 0/5=0.0
-        idx = curie2idx["HP:0012758"]
-        ndelay = patient_counts[idx]
-        ndelay_predicate = suox_pheno_clfs[idx]
-        max_f = IfHpoFilter.get_maximum_group_observed_HPO_frequency(
-            ndelay,
-            ph_clf=ndelay_predicate,
-        )
-        assert max_f == pytest.approx(0.5, abs=EPSILON)
-
-        # Hypertonia HP:0001276 (4 2 3 3) freqs are 4/7=0.4375 and 2/5=0.5714
-        idx = curie2idx["HP:0001276"]
-        hypertonia = patient_counts[idx]
-        hypertonia_predicate = suox_pheno_clfs[idx]
-        max_f = IfHpoFilter.get_maximum_group_observed_HPO_frequency(
-            hypertonia,
-            ph_clf=hypertonia_predicate,
-        )
-        assert max_f == pytest.approx(0.5714, abs=EPSILON)
-
-    # def test_mtc_filter_term_frequency_threshold_raises(
-    #     self,
-    #     hpo: hpotk.MinimalOntology,
-    # ):
-    #     with pytest.raises(AssertionError) as e:
-    #         IfHpoFilter.default_filter(
-    #             hpo=hpo,
-    #             term_frequency_threshold=1.1,
-    #             annotation_frequency_threshold=0.1,
-    #         )
-    #     assert e.value.args == (
-    #         "The term_frequency_threshold must be in the range (0, 1]",
-    #     )
-
     def test_mtc_filter_annotation_frequency_threshold_raises(
         self,
         hpo: hpotk.MinimalOntology,
@@ -238,7 +131,6 @@ class TestIfHpoFilter:
         with pytest.raises(AssertionError) as e:
             IfHpoFilter.default_filter(
                 hpo=hpo,
-                term_frequency_threshold=0.1,
                 annotation_frequency_threshold=1.1,
             )
         assert e.value.args == (

--- a/tests/view/conftest.py
+++ b/tests/view/conftest.py
@@ -52,7 +52,7 @@ def hpo_term_analysis_result(
         corrected_pvals=(math.nan, 0.01),
         mtc_filter_name="Random MTC filter",
         mtc_filter_results=(
-            PhenotypeMtcResult.fail("RMF01", "Not too interesting"),
+            PhenotypeMtcResult.fail("RMF01", "Not too interesting", doclink="https://www.example.com/boring"),
             PhenotypeMtcResult.ok(),
         ),
     )


### PR DESCRIPTION
Remove `HMF01`, provide links to MTC filter rules to simplify their interpretation.